### PR TITLE
Support for Boards and columns in export importer

### DIFF
--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -132,8 +132,9 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     return sourceMemberIds.contains(uid);
                 }).emptiesRemoved();
 
-                // TODO we are assuming that the columns appear in the export in the right order rather than sorting on rank
-                var columnNames = self.db().findByType("Column").filterProperty("pot", obj.__object_id).map(function(column) {
+                var columnNames = self.db().findByType("Column").filterProperty("pot", obj.__object_id).sort(function(columnA, columnB) {
+                    return columnA.rank.localeCompare(columnB.rank);
+                }).map(function(column) {
                     return column.name;
                 });
 

--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -117,6 +117,7 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
 
     projects: function() {
         var self = this;
+        var columnsBySourceProjectId = this.columnsBySourceProjectId();
         return this.db().findByType("ItemList").map(function(obj){
             if (obj.is_project && !obj.assignee) {
                 var sourceMemberIds = self.db().findByType("ProjectMembership").filterProperty("project", obj.__object_id).map(function(pm){
@@ -132,11 +133,7 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     return sourceMemberIds.contains(uid);
                 }).emptiesRemoved();
 
-                var columnNames = self.db().findByType("Column").filterProperty("pot", obj.__object_id).sort(function(columnA, columnB) {
-                    return columnA.rank.localeCompare(columnB.rank);
-                }).map(function(column) {
-                    return column.name;
-                });
+                var isBoard = columnsBySourceProjectId[obj.__object_id] !== undefined;
 
                 return ae.aei.Project.clone().performSets({
                     sourceId: obj.__object_id,
@@ -145,7 +142,7 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     archived: obj.is_archived || false,
                     public: obj.is_public_to_workspace || false,
                     color: obj.color || null,
-                    columnNames: columnNames,
+                    isBoard: isBoard,
                     sourceTeamId: obj.team || null,
                     sourceItemIds: obj.items,
                     sourceMemberIds: sourceMemberIds,
@@ -155,9 +152,9 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         }).filter(function(project) { return project && project.sourceTeamId(); });
     },
 
-    columns: function() {
+    columnsBySourceProjectId: function() {
         var self = this;
-        return self.db().findByType("Column").sort(function(columnA, columnB) {
+        var columns = self.db().findByType("Column").sort(function(columnA, columnB) {
             return columnA.rank.localeCompare(columnB.rank);
         }).map(function(obj) {
             return ae.aei.Column.clone().performSets({
@@ -166,6 +163,16 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                 sourceProjectId: obj.pot
             });
         });
+
+        var bySourceProjectId = {};
+        columns.forEach(function(column) {
+            var existing = bySourceProjectId[column.sourceProjectId()];
+            if (existing === undefined) {
+                bySourceProjectId[column.sourceProjectId()] = existing = [];
+            }
+            existing.push(column);
+        });
+        return bySourceProjectId;
     },
 
     tags: function() {

--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -183,18 +183,6 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         });
     },
 
-    columnsBySourceProjectId: function() {
-        var bySourceProjectId = {};
-        this.columns().forEach(function(column) {
-            var existing = bySourceProjectId[column.sourceProjectId()];
-            if (existing === undefined) {
-                bySourceProjectId[column.sourceProjectId()] = existing = [];
-            }
-            existing.push(column);
-        });
-        return bySourceProjectId;
-    },
-
     tags: function() {
         return this.db().findByType("ItemList").map(function(obj){
             if (!obj.is_project && !obj.assignee) {

--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -155,6 +155,19 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         }).filter(function(project) { return project && project.sourceTeamId(); });
     },
 
+    columns: function() {
+        var self = this;
+        return self.db().findByType("Column").sort(function(columnA, columnB) {
+            return columnA.rank.localeCompare(columnB.rank);
+        }).map(function(obj) {
+            return ae.aei.Column.clone().performSets({
+                sourceId: obj.__object_id,
+                name: obj.name,
+                sourceProjectId: obj.pot
+            });
+        });
+    },
+
     tags: function() {
         return this.db().findByType("ItemList").map(function(obj){
             if (!obj.is_project && !obj.assignee) {

--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -119,12 +119,24 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         var self = this;
         return this.db().findByType("ItemList").map(function(obj){
             if (obj.is_project && !obj.assignee) {
-                var sourceMemberIds = self.db().findByType("ProjectMembership").filterProperty("project", obj.__object_id).map(function(pm){ return Object.perform(self._userForDomainUserId(pm.member), "sourceId") }).emptiesRemoved();
+                var sourceMemberIds = self.db().findByType("ProjectMembership").filterProperty("project", obj.__object_id).map(function(pm){
+                    return Object.perform(self._userForDomainUserId(pm.member), "sourceId")
+                }).emptiesRemoved();
                 // In product we filter the followers list and only count as valid those which are also members. However
                 // the export includes all followers regardless of whether or not they are members. Everyone who is added
                 // as a follower via the API is automatically added as a member, so to avoid granting people additional
                 // access we need to filter out non-member followers.
-                var sourceFollowerIds = obj.followers_du.map(function(duid){ return Object.perform(self._userForDomainUserId(duid), "sourceId") }).filter(function(uid){ return sourceMemberIds.contains(uid); }).emptiesRemoved();
+                var sourceFollowerIds = obj.followers_du.map(function(duid){
+                    return Object.perform(self._userForDomainUserId(duid), "sourceId")
+                }).filter(function(uid){
+                    return sourceMemberIds.contains(uid);
+                }).emptiesRemoved();
+
+                // TODO we are assuming that the columns appear in the export in the right order rather than sorting on rank
+                var columnNames = self.db().findByType("Column").filterProperty("pot", obj.__object_id).map(function(column) {
+                    return column.name;
+                });
+
                 return ae.aei.Project.clone().performSets({
                     sourceId: obj.__object_id,
                     name: obj.name,
@@ -132,6 +144,7 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     archived: obj.is_archived || false,
                     public: obj.is_public_to_workspace || false,
                     color: obj.color || null,
+                    columnNames: columnNames,
                     sourceTeamId: obj.team || null,
                     sourceItemIds: obj.items,
                     sourceMemberIds: sourceMemberIds,

--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -23,6 +23,7 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
 
     prepareForImport: function() {
         this._processExportFile();
+        this._populateJoinObjectRelationships();
     },
 
     cleanupAfterImport: function() {
@@ -79,6 +80,18 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
             this._caches[name] = this[name]();
         }
         return this._caches[name];
+    },
+
+    _populateJoinObjectRelationships: function() {
+        console.log("Populating join objects");
+        this._populateColumnTaskRelationships();
+    },
+
+    _populateColumnTaskRelationships: function() {
+        var self = this;
+        this.db().findByType("ColumnTask").forEach(function(obj) {
+            self.db().insertOrderedRelationship(obj.column, obj.task, obj.rank);
+        });
     },
 
     users: function() {
@@ -152,20 +165,27 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         }).filter(function(project) { return project && project.sourceTeamId(); });
     },
 
-    columnsBySourceProjectId: function() {
+    columns: function() {
         var self = this;
-        var columns = self.db().findByType("Column").sort(function(columnA, columnB) {
+        return self.db().findByType("Column").sort(function(columnA, columnB) {
             return columnA.rank.localeCompare(columnB.rank);
         }).map(function(obj) {
+            var tasks = self.db().findOrderedChildrenByType(obj.__object_id, "Task").map(function(task) {
+                return task.__object_id;
+            });
+
             return ae.aei.Column.clone().performSets({
                 sourceId: obj.__object_id,
                 name: obj.name,
-                sourceProjectId: obj.pot
+                sourceProjectId: obj.pot,
+                sourceItemIds: tasks
             });
         });
+    },
 
+    columnsBySourceProjectId: function() {
         var bySourceProjectId = {};
-        columns.forEach(function(column) {
+        this.columns().forEach(function(column) {
             var existing = bySourceProjectId[column.sourceProjectId()];
             if (existing === undefined) {
                 bySourceProjectId[column.sourceProjectId()] = existing = [];

--- a/lib/asana_export/AsanaExportDb.js
+++ b/lib/asana_export/AsanaExportDb.js
@@ -11,6 +11,8 @@ var ImporterDb = module.exports = ae.aei.SQLiteDb.extend().newSlots({
         this.run("CREATE TABLE relationships(parentId BIGINTEGER, childId BIGINTEGER)");
         this.run("CREATE INDEX relationships_parentId ON relationships(parentId)");
         this.run("CREATE INDEX relationships_childId ON relationships(childId)");
+        this.run("CREATE TABLE ordered_relationships(parentId BIGINTEGER, childId BIGINTEGER, rank TEXT)");
+        this.run("CREATE INDEX ordered_relationships_parentId ON ordered_relationships(parentId, rank)");
     },
 
     insert: function(obj) {
@@ -28,6 +30,10 @@ var ImporterDb = module.exports = ae.aei.SQLiteDb.extend().newSlots({
                 self.run("INSERT INTO relationships(parentId, childId) VALUES(?,?)", [parent.__object_id, childId]);
             });
         }
+    },
+
+    insertOrderedRelationship: function(parentId, childId, rank) {
+        this.run("INSERT INTO ordered_relationships(parentId, childId, rank) VALUES(?,?,?)", [parentId, childId, rank]);
     },
 
     findByType: function(type, offset, limit) {
@@ -77,6 +83,10 @@ var ImporterDb = module.exports = ae.aei.SQLiteDb.extend().newSlots({
 
     findParentsByType: function(childId, type) {
         return this.allObjects("SELECT data FROM objects, relationships WHERE childId = ? AND sourceId = parentId AND type = ?", [childId, type]);
+    },
+
+    findOrderedChildrenByType: function(parentId, type) {
+        return this.allObjects("SELECT data FROM objects, ordered_relationships WHERE parentId = ? AND sourceId = childId AND type = ? ORDER BY rank", [parentId, type]);
     },
 
     findById: function(sourceId) {

--- a/lib/asana_export_importer/Export.js
+++ b/lib/asana_export_importer/Export.js
@@ -24,6 +24,10 @@ var Export = module.exports = aei.ideal.Proto.extend().setType("Export").newSlot
         throw "Clones should override";
     },
 
+    columnsBySourceProjectId: function() {
+        throw "Clones should override, returning an object with values being arrays of Columns, and keys being the value of the sourceProjectId slot";
+    },
+
     tags: function() {
         throw "Clones should override";
     },

--- a/lib/asana_export_importer/Export.js
+++ b/lib/asana_export_importer/Export.js
@@ -5,35 +5,43 @@ var Export = module.exports = aei.ideal.Proto.extend().setType("Export").newSlot
     batchSize: 100
 }).setSlots({
     prepareForImport: function() {
-        throw "Clones should override";
+        throw new Error("Clones should override");
     },
 
     cleanupAfterImport: function() {
-        throw "Clones should override";
+        throw new Error("Clones should override");
     },
 
     users: function() {
-        throw "Clones should override";
+        throw new Error("Clones should override");
     },
 
     teams: function() {
-        throw "Clones should override";
+        throw new Error("Clones should override");
     },
 
     projects: function() {
-        throw "Clones should override";
+        throw new Error("Clones should override");
     },
 
     columns: function() {
-        throw "Clones should override";
+        throw new Error("Clones should override");
     },
 
     columnsBySourceProjectId: function() {
-        throw "Clones should override, returning an object with values being arrays of Columns, and keys being the value of the sourceProjectId slot";
+        var bySourceProjectId = {};
+        this.columns().forEach(function(column) {
+            var existing = bySourceProjectId[column.sourceProjectId()];
+            if (existing === undefined) {
+                bySourceProjectId[column.sourceProjectId()] = existing = [];
+            }
+            existing.push(column);
+        });
+        return bySourceProjectId;
     },
 
     tags: function() {
-        throw "Clones should override";
+        throw new Error("Clones should override");
     },
 
     taskIterable: function() {
@@ -59,10 +67,10 @@ var Export = module.exports = aei.ideal.Proto.extend().setType("Export").newSlot
     },
 
     taskDataSource: function() {
-        throw "Clones should return a function with the following signature: function(position, chunkSize) returns [aei.Task, ...]";
+        throw new Error("Clones should return a function with the following signature: function(position, chunkSize) returns [aei.Task, ...]");
     },
 
     attachmentDataSource: function() {
-        throw "Clones should return a function with the following signature: function(position, chunkSize) returns [aei.Attachment, ...]";
+        throw new Error("Clones should return a function with the following signature: function(position, chunkSize) returns [aei.Attachment, ...]");
     }
 });

--- a/lib/asana_export_importer/Export.js
+++ b/lib/asana_export_importer/Export.js
@@ -24,6 +24,10 @@ var Export = module.exports = aei.ideal.Proto.extend().setType("Export").newSlot
         throw "Clones should override";
     },
 
+    columns: function() {
+        throw "Clones should override";
+    },
+
     columnsBySourceProjectId: function() {
         throw "Clones should override, returning an object with values being arrays of Columns, and keys being the value of the sourceProjectId slot";
     },

--- a/lib/asana_export_importer/Importer.js
+++ b/lib/asana_export_importer/Importer.js
@@ -54,10 +54,22 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
     },
 
     _importColumns: function() {
-        this._forEachOfType("column", function(column) {
-            column.performSets({
-                project: this.app().sourceToAsanaMap().at(column.sourceProjectId())
-            }).create();
+        var self = this;
+        var columnsBySourceProjectId = this.export().columnsBySourceProjectId();
+        this._forEachOfType("project", function(project) {
+            var thisProjectColumns = columnsBySourceProjectId[project.sourceId()];
+
+            if (thisProjectColumns === undefined) {
+                // No columns in this project
+                return;
+            }
+
+            thisProjectColumns.forEach(function(column, index) {
+                console.log("Adding Column " + index + " to Project [source=" + project.sourceId() + ", asana=" + project.asanaId() + "]");
+                column.performSets({
+                    project: self.app().sourceToAsanaMap().at(column.sourceProjectId())
+                }).create();
+            });
         }, "importing columns");
     },
 
@@ -192,7 +204,7 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
 
         console.log("completed " + description + "\n");
     },
-    
+
     _addItemsToObject: function(object) {
         var self = this;
         object.sourceItemIds().reverse().forEach(function(sourceItemId, index) {

--- a/lib/asana_export_importer/Importer.js
+++ b/lib/asana_export_importer/Importer.js
@@ -24,6 +24,7 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
         this._addSubtasksToTasks();
         this._addTasksToProjects();
         this._addTasksToTags();
+        this._addTasksToColumns();
 
         this._importUsers();
 
@@ -132,6 +133,10 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
 
     _addTasksToTags: function() {
         this._forEachOfType("tag", this._addItemsToObject, "adding tasks to tags");
+    },
+
+    _addTasksToColumns: function() {
+        this._forEachOfType("column", this._addItemsToObject, "adding tasks to columns");
     },
 
     _addAssigneesToTasks: function() {

--- a/lib/asana_export_importer/Importer.js
+++ b/lib/asana_export_importer/Importer.js
@@ -14,6 +14,7 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
     _runImport: function() {
         this._importTeams();
         this._importProjects();
+        this._importColumns();
         this._importTags();
 
         this._importTasks();
@@ -50,6 +51,14 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
                 project.create();
             }
         }, "importing projects");
+    },
+
+    _importColumns: function() {
+        this._forEachOfType("column", function(column) {
+            column.performSets({
+                project: this.app().sourceToAsanaMap().at(column.sourceProjectId())
+            }).create();
+        }, "importing columns");
     },
 
     _importTags: function() {

--- a/lib/asana_export_importer/MockExport.js
+++ b/lib/asana_export_importer/MockExport.js
@@ -6,7 +6,8 @@ var MockExportData = aei.ideal.Proto.extend().setType("MockExportData").newSlots
     projects: [],
     tags: [],
     tasks: [],
-    attachments: []
+    attachments: [],
+    columns: []
 });
 
 var MockExport = module.exports =  aei.Export.extend().newSlots({
@@ -41,6 +42,12 @@ var MockExport = module.exports =  aei.Export.extend().newSlots({
     projects: function() {
         return this.data().projects().map(function(project) {
             return aei.Project.clone().performSets(project);
+        });
+    },
+
+    columns: function() {
+        return this.data().columns().map(function(column) {
+            return aei.Column.clone().performSets(column);
         });
     },
 

--- a/lib/asana_export_importer/index.js
+++ b/lib/asana_export_importer/index.js
@@ -19,6 +19,7 @@ module.exports.asana = require("asana");
     "SQLiteDb",
     "models/ImportObject",
     "models/Attachment",
+    "models/Column",
     "models/Project",
     "models/Tag",
     "models/Task",

--- a/lib/asana_export_importer/models/Column.js
+++ b/lib/asana_export_importer/models/Column.js
@@ -1,4 +1,5 @@
 var aei = require("../");
+var util = require('util');
 
 var Column = module.exports = aei.ImportObject.extend().performSets({
     type: "Column",
@@ -6,6 +7,7 @@ var Column = module.exports = aei.ImportObject.extend().performSets({
 }).newSlots({
     name: null,
     sourceProjectId: null,
+    sourceItemIds: null,
     project: null
 }).setSlots({
     _createResource: function(resourceData) {
@@ -13,6 +15,16 @@ var Column = module.exports = aei.ImportObject.extend().performSets({
         var dispatcher = this.app().apiClient().dispatcher;
 
         return aei.Future.withPromise(dispatcher.post('/columns', resourceData)).wait();
+    },
+
+    // Adds a task at the top of the column
+    addItem: function(taskAsanaId) {
+        // The current version of the Asana node client library is not aware of Columns, so we have to do it manually
+        var path = util.format('/columns/%s/addTask', this.asanaId());
+        var dispatcher = this.app().apiClient().dispatcher;
+        return aei.Future.withPromise(dispatcher.post(path, {
+            task: taskAsanaId
+        })).wait();
     },
 
     _resourceData: function() {

--- a/lib/asana_export_importer/models/Column.js
+++ b/lib/asana_export_importer/models/Column.js
@@ -1,0 +1,24 @@
+var aei = require("../");
+
+var Column = module.exports = aei.ImportObject.extend().performSets({
+    type: "Column",
+    resourceName: "columns"
+}).newSlots({
+    name: null,
+    sourceProjectId: null,
+    project: null
+}).setSlots({
+    _createResource: function(resourceData) {
+        // The current version of the Asana node client library is not aware of Columns, so we have to do it manually
+        var dispatcher = this.app().apiClient().dispatcher;
+
+        return aei.Future.withPromise(dispatcher.post('/columns', resourceData)).wait();
+    },
+
+    _resourceData: function() {
+        return {
+            name: this.name(),
+            project: this.project()
+        };
+    }
+});

--- a/lib/asana_export_importer/models/Project.js
+++ b/lib/asana_export_importer/models/Project.js
@@ -10,7 +10,7 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
     archived: null,
     public: false,
     color: null,
-    columnNames: null,
+    isBoard: false,
     sourceTeamId: null,
     sourceItemIds: null,
     sourceMemberIds: null,
@@ -37,21 +37,6 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
         })).wait();
     },
 
-    _createResource: function(resourceData) {
-        // We need to see what IDs the columns were assigned, but we need to create columns as part of creating the
-        // project, not as a separate object.
-        var postResponse = aei.Future.withPromise(this._resource().create(resourceData)).wait();
-        console.log("Post response", postResponse)
-
-        var getResponse = aei.Future.withPromise(this._resource().findById(postResponse.id, {
-            // opt_fields: "columns"
-        })).wait();
-
-        console.log("Get response", getResponse)
-
-        return postResponse;
-    },
-
     _resourceData: function() {
         return {
             workspace: this.workspaceId(),
@@ -61,11 +46,10 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
             public: this.public(),
             color: this.color(),
             team: this.asanaTeamId(),
-            columns: this.columnNames().map(function(columnName) {
-                return {
-                    name: columnName
-                };
-            })
+            // #BoardsEmptyState An empty board is a project with one column whose name is "" (EmptyBoardDefaultColumnName)
+            // We don't actually add the columns here because we can only capture their ID (for later adding tasks to)
+            // if they are a resource
+            columns: this.isBoard() ? [ { name: "" } ] : undefined
         };
     },
 });

--- a/lib/asana_export_importer/models/Project.js
+++ b/lib/asana_export_importer/models/Project.js
@@ -10,6 +10,7 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
     archived: null,
     public: false,
     color: null,
+    columnNames: null,
     sourceTeamId: null,
     sourceItemIds: null,
     sourceMemberIds: null,
@@ -44,7 +45,12 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
             archived: this.archived(),
             public: this.public(),
             color: this.color(),
-            team: this.asanaTeamId()
+            team: this.asanaTeamId(),
+            columns: this.columnNames().map(function(columnName) {
+                return {
+                    name: columnName
+                };
+            })
         };
     },
 });

--- a/lib/asana_export_importer/models/Project.js
+++ b/lib/asana_export_importer/models/Project.js
@@ -37,6 +37,21 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
         })).wait();
     },
 
+    _createResource: function(resourceData) {
+        // We need to see what IDs the columns were assigned, but we need to create columns as part of creating the
+        // project, not as a separate object.
+        var postResponse = aei.Future.withPromise(this._resource().create(resourceData)).wait();
+        console.log("Post response", postResponse)
+
+        var getResponse = aei.Future.withPromise(this._resource().findById(postResponse.id, {
+            // opt_fields: "columns"
+        })).wait();
+
+        console.log("Get response", getResponse)
+
+        return postResponse;
+    },
+
     _resourceData: function() {
         return {
             workspace: this.workspaceId(),

--- a/test/asana_export_importer/Importer.js
+++ b/test/asana_export_importer/Importer.js
@@ -28,6 +28,8 @@ describe("Importer", function() {
         sinon.spy(client.tasks, "update");
         sinon.spy(client.stories, "createOnTask");
         sinon.spy(client.workspaces, "addUser");
+
+        sinon.spy(client.dispatcher, "post");
     });
     
     afterEach(function() {
@@ -86,7 +88,75 @@ describe("Importer", function() {
 
             client.projects.create.should.have.been.calledOnce;
             client.tags.create.should.not.have.been.called;
-            client.projects.create.getCall(0).args[0]['team'].should.equal(app.sourceToAsanaMap().at(100))
+            var resourceData = client.projects.create.getCall(0).args[0];
+            resourceData['team'].should.equal(app.sourceToAsanaMap().at(100));
+
+            // Since we didn't specify that it was a board, it should have no columns
+            (resourceData['columns'] === undefined).should.be.true;
+        });
+
+        it("should create a board", function() {
+            exp.setMockData({
+                teams: [{ sourceId: 100, name: "team1", teamType: "PUBLIC", sourceMemberIds: [] }],
+                projects: [{ sourceId: 101, name: "project1", sourceTeamId: 100, sourceMemberIds: [], isBoard: true }]
+            });
+
+            importer._importTeams();
+            importer._importProjects();
+
+            client.projects.create.should.have.been.calledOnce;
+            client.projects.create.getCall(0).args[0]['columns'].should.deep.equal([{ name: "" }]);
+        });
+    });
+
+    describe("#_importColumns()", function() {
+        it("should create a column", function() {
+            exp.setMockData({
+                projects: [{sourceId: 101, name: "project1", sourceTeamId: 100, sourceMemberIds: [], isBoard: true}],
+                columns: [{sourceId: 102, name: "column1", sourceProjectId: 101, sourceItemIds: []}]
+            });
+
+            importer._importColumns();
+
+            // The client library doesn't support boards/columns yet, so we expect the dispatcher to have been
+            // used directly
+            client.dispatcher.post.should.have.been.calledOnce;
+            client.dispatcher.post.should.have.been.calledWithExactly("/columns", {
+                name: "column1",
+                project: app.sourceToAsanaMap().at(101)
+            });
+        });
+    });
+
+    describe("#_addTasksToColumns()", function() {
+        it("should put some tasks in a column", function() {
+            exp.setMockData({
+                projects: [{sourceId: 103, name: "project1", sourceTeamId: 100, sourceMemberIds: [], isBoard: true}],
+                tasks: [
+                    { sourceId: 100, name: "task1", sourceFollowerIds: [], sourceItemIds: [] },
+                    { sourceId: 101, name: "task2", sourceFollowerIds: [], sourceItemIds: [] }
+                ],
+                columns: [{sourceId: 102, name: "column1", sourceProjectId: 103, sourceItemIds: [100, 101]}]
+            });
+
+            importer._importTasks();
+            importer._importColumns();
+            importer._addTasksToColumns();
+
+            // The client library doesn't support boards/columns yet, so we expect the dispatcher to have been
+            // used directly
+            // The first two calls to dispatcher.post will be to create the tasks, then one for the column.
+            // Calls 3 and 4 should be adding to columns, in reverse order
+            client.dispatcher.post.should.have.callCount(5);
+            app.sourceToAsanaMap().at(102).should.not.be.null;
+            client.dispatcher.post.getCall(3).args.should.deep.equal([
+                "/columns/" + app.sourceToAsanaMap().at(102) + "/addTask",
+                { task: app.sourceToAsanaMap().at(101) }
+            ]);
+            client.dispatcher.post.getCall(4).args.should.deep.equal([
+                "/columns/" + app.sourceToAsanaMap().at(102) + "/addTask",
+                { task: app.sourceToAsanaMap().at(100) }
+            ]);
         });
     });
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -87,7 +87,7 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.projects().mapPerform("toJS")).to.deep.equal([
-                { sourceId: 200, name: "project1", notes: "desc", archived: false, public: false, color: null, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [] }
+                { sourceId: 200, name: "project1", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [] }
             ]);
 
             importer._importTeams();
@@ -95,7 +95,7 @@ describe("Integration", function() {
 
             expect(client.teams.create).to.have.callCount(1);
             expect(client.projects.create).to.have.callCount(1);
-            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project1", notes: "desc", archived: false, public: false, color: null, team: app.sourceToAsanaMap().at(100) });
+            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project1", notes: "desc", archived: false, public: false, color: null, columns: undefined, team: app.sourceToAsanaMap().at(100) });
         });
 
         it("should create projects with correct 'public' fields (and defaults to false)", function() {
@@ -106,18 +106,18 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.projects().mapPerform("toJS")).to.deep.equal([
-                { sourceId: 200, name: "project1", notes: "desc", archived: false, public: true, color: null, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [] },
-                { sourceId: 201, name: "project2", notes: "desc", archived: false, public: false, color: null, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [] },
-                { sourceId: 202, name: "project3", notes: "desc", archived: false, public: false, color: null, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [] }
+                { sourceId: 200, name: "project1", notes: "desc", archived: false, public: true, color: null, isBoard: false, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [] },
+                { sourceId: 201, name: "project2", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [] },
+                { sourceId: 202, name: "project3", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [] }
             ]);
 
             importer._importTeams();
             importer._importProjects();
 
             expect(client.projects.create).to.have.callCount(3);
-            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project1", notes: "desc", archived: false, public: true, color: null, team: app.sourceToAsanaMap().at(100) });
-            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project2", notes: "desc", archived: false, public: false, color: null, team: app.sourceToAsanaMap().at(100) });
-            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project3", notes: "desc", archived: false, public: false, color: null, team: app.sourceToAsanaMap().at(100) });
+            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project1", notes: "desc", archived: false, public: true, color: null, columns: undefined, team: app.sourceToAsanaMap().at(100) });
+            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project2", notes: "desc", archived: false, public: false, color: null, columns: undefined, team: app.sourceToAsanaMap().at(100) });
+            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project3", notes: "desc", archived: false, public: false, color: null, columns: undefined, team: app.sourceToAsanaMap().at(100) });
         });
 
         it("should not create projects for tags or ATMs", function() {
@@ -366,7 +366,7 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.projects().mapPerform("toJS")).to.deep.equal([
-                { sourceId: 200, name: "project1", notes: "desc", sourceTeamId: 100, sourceMemberIds: [], sourceItemIds: [301, 300], sourceFollowerIds: [], archived: false, color: null, public: false }
+                { sourceId: 200, name: "project1", notes: "desc", sourceTeamId: 100, sourceMemberIds: [], sourceItemIds: [301, 300], sourceFollowerIds: [], archived: false, color: null, isBoard: false, public: false }
             ]);
 
             importer._importTeams();
@@ -623,7 +623,7 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.projects().mapPerform("toJS")).to.deep.equal([
-                { sourceId: 400, name: "project1", notes: "desc", archived: false, public: false, color: null, sourceTeamId: 300, sourceItemIds: [], sourceFollowerIds: [], sourceMemberIds: [100, 101] }
+                { sourceId: 400, name: "project1", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 300, sourceItemIds: [], sourceFollowerIds: [], sourceMemberIds: [100, 101] }
             ]);
 
             importer._importTeams();
@@ -660,7 +660,7 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.projects().mapPerform("toJS")).to.deep.equal([
-                { sourceId: 400, name: "project1", notes: "desc", archived: false, public: false, color: null, sourceTeamId: 300, sourceItemIds: [], sourceFollowerIds: [100, 101], sourceMemberIds: [100, 101] }
+                { sourceId: 400, name: "project1", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 300, sourceItemIds: [], sourceFollowerIds: [100, 101], sourceMemberIds: [100, 101] }
             ]);
 
             importer._importTeams();

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -25,6 +25,7 @@ global.AsanaExportInMemory = ae.AsanaExport.extend().setSlots({
         var self = this;
         this.db().create();
         this._readLines({ readLine: function() { return JSON.stringify(self._lines.shift()); } });
+        this._populateJoinObjectRelationships();
     },
     cleanupAfterImport: function() {
     },


### PR DESCRIPTION
Creates a new resource called Column, which "contains" tasks in the same way that a project contains tasks.
A project is created as an empty board, and then the columns are added to it, because if we just create a project with all columns pre-existing, there's no way to learn the ID of the columns, to add tasks to them later. This means this code is aware of the #BoardsEmptyState hack.
Since the export contains ColumnTask join objects rather than just listing the contents of a column in the same way it lists the contents of a project, needed to introduce the concept of an ordered parent-child relationship to the AsanaExportDB, which can store the rank of the ColumnTasks and allow the AsanaExport to return them in order.
Since boards/columns are not yet a documented part of the API, they don't exist in the client libraries, so we use a lower level of the client library to make direct posts.

Testing plan:
All three kinds of tests (which seem kinda redundant, but are good if we want to split out the importer for various input sources later)