### PR TITLE
Tolerate Columns with an empty string for their name

### DIFF
--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -176,9 +176,10 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                 return task.__object_id;
             });
 
+            var columnName = obj.name === "" ? "Unnamed column" : obj.name;
             return ae.aei.Column.clone().performSets({
                 sourceId: obj.__object_id,
-                name: obj.name,
+                name: columnName,
                 sourceProjectId: obj.pot,
                 sourceItemIds: tasks
             });

--- a/test/asana_export/AsanaExport.js
+++ b/test/asana_export/AsanaExport.js
@@ -152,6 +152,15 @@ describe("AsanaExport", function() {
                 { sourceId: 1, name: "First column", sourceProjectId: 12345, sourceItemIds: [10,11,12] }
             ]);
         });
+
+        it("should give name to a column with empty name", function() {
+            exp.addObject(1, "Column", { name: "", pot: 12345, rank: "V" });
+            exp.prepareForImport();
+
+            exp.columns().mapPerform("performGets", ["sourceId", "name", "sourceProjectId", "sourceItemIds"]).should.deep.equal([
+                { sourceId: 1, name: "Unnamed column", sourceProjectId: 12345, sourceItemIds: [] }
+            ]);
+        });
     });
 
     describe("#columnsBySourceProjectId()", function() {


### PR DESCRIPTION
The most common source of these are boards with no columns, which use a single unnamed column as a marker
We import those as a board with one column called "Unnamed column", which is strictly incorrect, but won't get in any users' way