### PR TITLE
Simplify API call to create a board project, I didn't realize there w…

### DIFF
--- a/lib/asana_export_importer/models/Project.js
+++ b/lib/asana_export_importer/models/Project.js
@@ -46,10 +46,7 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
             public: this.public(),
             color: this.color(),
             team: this.asanaTeamId(),
-            // #BoardsEmptyState An empty board is a project with one column whose name is "" (EmptyBoardDefaultColumnName)
-            // We don't actually add the columns here because we can only capture their ID (for later adding tasks to)
-            // if they are a resource
-            columns: this.isBoard() ? [ { name: "" } ] : undefined
+            layout: this.isBoard() ? "BOARD" : "LIST"
         };
     },
 });

--- a/test/asana_export_importer/Importer.js
+++ b/test/asana_export_importer/Importer.js
@@ -91,8 +91,8 @@ describe("Importer", function() {
             var resourceData = client.projects.create.getCall(0).args[0];
             resourceData['team'].should.equal(app.sourceToAsanaMap().at(100));
 
-            // Since we didn't specify that it was a board, it should have no columns
-            (resourceData['columns'] === undefined).should.be.true;
+            // Since we didn't specify that it was a board, it should have list layout
+            resourceData['layout'].should.equal("LIST");
         });
 
         it("should create a board", function() {
@@ -105,7 +105,7 @@ describe("Importer", function() {
             importer._importProjects();
 
             client.projects.create.should.have.been.calledOnce;
-            client.projects.create.getCall(0).args[0]['columns'].should.deep.equal([{ name: "" }]);
+            client.projects.create.getCall(0).args[0]['layout'].should.equal("BOARD");
         });
     });
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -95,7 +95,7 @@ describe("Integration", function() {
 
             expect(client.teams.create).to.have.callCount(1);
             expect(client.projects.create).to.have.callCount(1);
-            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project1", notes: "desc", archived: false, public: false, color: null, columns: undefined, team: app.sourceToAsanaMap().at(100) });
+            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project1", notes: "desc", archived: false, public: false, color: null, layout: "LIST", team: app.sourceToAsanaMap().at(100) });
         });
 
         it("should create projects with correct 'public' fields (and defaults to false)", function() {
@@ -115,9 +115,9 @@ describe("Integration", function() {
             importer._importProjects();
 
             expect(client.projects.create).to.have.callCount(3);
-            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project1", notes: "desc", archived: false, public: true, color: null, columns: undefined, team: app.sourceToAsanaMap().at(100) });
-            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project2", notes: "desc", archived: false, public: false, color: null, columns: undefined, team: app.sourceToAsanaMap().at(100) });
-            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project3", notes: "desc", archived: false, public: false, color: null, columns: undefined, team: app.sourceToAsanaMap().at(100) });
+            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project1", notes: "desc", archived: false, public: true, color: null, layout: "LIST", team: app.sourceToAsanaMap().at(100) });
+            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project2", notes: "desc", archived: false, public: false, color: null, layout: "LIST", team: app.sourceToAsanaMap().at(100) });
+            expect(client.projects.create).to.have.been.calledWithExactly({ workspace: orgId, name: "project3", notes: "desc", archived: false, public: false, color: null, layout: "LIST", team: app.sourceToAsanaMap().at(100) });
         });
 
         it("should not create projects for tags or ATMs", function() {


### PR DESCRIPTION
…as a layout property before

Test plan:
Adapted the unit tests and ran a test import to production, containing a board, and checked that it came out right