### PR TITLE
Support for custom fields

### DIFF
--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -138,6 +138,21 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         });
     },
 
+    customFieldProtos: function() {
+        var self = this;
+        var textProtos = this.db().findByType("CustomPropertyTextProto").map(function(obj) {
+            return ae.aei.CustomFieldProto.clone().performSets({
+                sourceId: obj.__object_id,
+                name: obj.name,
+                description: obj.description,
+                type: "text"
+            });
+        });
+
+        // TODO number and enum protos, factoring out shared performSets??
+        return textProtos;
+    },
+
     projects: function() {
         var self = this;
         var columnsBySourceProjectId = this.columnsBySourceProjectId();

--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -88,6 +88,7 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         console.log("Populating join objects");
         this._populateColumnTaskRelationships();
         this._populateTaskDependencyRelationships();
+        this._populateCustomPropertyEnumOptions();
     },
 
     _populateColumnTaskRelationships: function() {
@@ -101,6 +102,13 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         var self = this;
         this.db().findByType("TaskDependency").forEach(function(obj) {
             self.db().insertRelationship("task_dependency", obj.dependent, obj.precedent);
+        });
+    },
+
+    _populateCustomPropertyEnumOptions: function() {
+        var self = this;
+        this.db().findByType("CustomPropertyEnumOption").forEach(function(obj) {
+            self.db().insertOrderedRelationship("custom_field_enum_option", obj.proto, obj.__object_id, obj.rank);
         });
     },
 
@@ -140,17 +148,42 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
 
     customFieldProtos: function() {
         var self = this;
-        var textProtos = this.db().findByType("CustomPropertyTextProto").map(function(obj) {
+        var createBasicCustomFieldProto = function(obj) {
             return ae.aei.CustomFieldProto.clone().performSets({
                 sourceId: obj.__object_id,
                 name: obj.name,
-                description: obj.description,
+                description: obj.description
+            });
+        };
+
+        var textProtos = self.db().findByType("CustomPropertyTextProto").map(function(obj) {
+            return createBasicCustomFieldProto(obj).performSets({
                 type: "text"
             });
         });
 
-        // TODO number and enum protos, factoring out shared performSets??
-        return textProtos;
+        var numberProtos = self.db().findByType("CustomPropertyNumberProto").map(function(obj) {
+            return createBasicCustomFieldProto(obj).performSets({
+                type: "number",
+                precision: obj.precision
+            });
+        });
+
+        var enumProtos = self.db().findByType("CustomPropertyEnumProto").map(function(obj) {
+            var options = self.db().findOrderedChildrenByType("custom_field_enum_option", obj.__object_id, "CustomPropertyEnumOption").map(function(option) {
+                return {
+                    name: option.name,
+                    enabled: !option.is_archived,
+                    color: option.color
+                };
+            });
+            return createBasicCustomFieldProto(obj).performSets({
+                type: "enum",
+                options: options
+            });
+        });
+
+        return textProtos.concat(numberProtos, enumProtos);
     },
 
     projects: function() {

--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -89,6 +89,7 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         this._populateColumnTaskRelationships();
         this._populateTaskDependencyRelationships();
         this._populateCustomPropertyEnumOptions();
+        this._populateCustomPropertyProjectSettings();
     },
 
     _populateColumnTaskRelationships: function() {
@@ -109,6 +110,13 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         var self = this;
         this.db().findByType("CustomPropertyEnumOption").forEach(function(obj) {
             self.db().insertOrderedRelationship("custom_field_enum_option", obj.proto, obj.__object_id, obj.rank);
+        });
+    },
+
+    _populateCustomPropertyProjectSettings: function() {
+        var self = this;
+        this.db().findByType("CustomPropertyProjectSetting").forEach(function(obj) {
+            self.db().insertOrderedRelationship("custom_field_project_settings", obj.project, obj.__object_id, obj.rank);
         });
     },
 
@@ -207,6 +215,13 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
 
                 var isBoard = columnsBySourceProjectId[obj.__object_id] !== undefined;
 
+                var customFieldSettings = self.db().findOrderedChildrenByType("custom_field_project_settings", obj.__object_id, "CustomPropertyProjectSetting").map(function(projectSetting) {
+                    return {
+                        sourceCustomFieldProtoId: projectSetting.proto,
+                        isImportant: projectSetting.is_important
+                    };
+                });
+
                 return ae.aei.Project.clone().performSets({
                     sourceId: obj.__object_id,
                     name: obj.name,
@@ -218,7 +233,8 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     sourceTeamId: obj.team || null,
                     sourceItemIds: obj.items,
                     sourceMemberIds: sourceMemberIds,
-                    sourceFollowerIds: sourceFollowerIds
+                    sourceFollowerIds: sourceFollowerIds,
+                    customFieldSettings: customFieldSettings
                 });
             }
         }).filter(function(project) { return project && project.sourceTeamId(); });

--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -90,6 +90,7 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         this._populateTaskDependencyRelationships();
         this._populateCustomPropertyEnumOptions();
         this._populateCustomPropertyProjectSettings();
+        this._populateCustomPropertyValues();
     },
 
     _populateColumnTaskRelationships: function() {
@@ -117,6 +118,15 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         var self = this;
         this.db().findByType("CustomPropertyProjectSetting").forEach(function(obj) {
             self.db().insertOrderedRelationship("custom_field_project_settings", obj.project, obj.__object_id, obj.rank);
+        });
+    },
+
+    _populateCustomPropertyValues: function() {
+        var self = this;
+        ["CustomPropertyTextValue", "CustomPropertyNumberValue", "CustomPropertyEnumValue"].forEach(function(typeName) {
+            self.db().findByType(typeName).forEach(function(obj) {
+                self.db().insertRelationship("custom_field_values", obj.object, obj.__object_id);
+            });
         });
     },
 
@@ -300,6 +310,25 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     return task.__object_id;
                 });
 
+                var customFieldValues = self.db().findChildrenByTypesLike("custom_field_values", obj.__object_id, ["CustomProperty%Value"]).map(function(value) {
+                    var toReturn = {
+                        protoSourceId: value.proto
+                    };
+
+                    if (value.__type === "CustomPropertyTextValue") {
+                        toReturn.type = "text";
+                        toReturn.value = value.text;
+                    } else  if (value.__type === "CustomPropertyNumberValue") {
+                        toReturn.type = "number";
+                        toReturn.value = value.digits;
+                    } else if (value.__type === "CustomPropertyEnumValue") {
+                        toReturn.type = "enum";
+                        toReturn.value = value.option;
+                    }
+
+                    return toReturn;
+                });
+
                 return ae.aei.Task.clone().performSets({
                     sourceId: obj.__object_id,
                     name: obj.name,
@@ -317,7 +346,8 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     sourceBlockingTaskIds: blockingTaskIds,
                     stories: [creationStory].concat(realStories),
                     recurrenceType: obj.recurrence_type || null,
-                    recurrenceData: obj.recurrence_json || null
+                    recurrenceData: obj.recurrence_json || null,
+                    customFieldValues: customFieldValues
                 });
             });
         }

--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -172,6 +172,7 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
         var enumProtos = self.db().findByType("CustomPropertyEnumProto").map(function(obj) {
             var options = self.db().findOrderedChildrenByType("custom_field_enum_option", obj.__object_id, "CustomPropertyEnumOption").map(function(option) {
                 return {
+                    sourceId: option.__object_id,
                     name: option.name,
                     enabled: !option.is_archived,
                     color: option.color

--- a/lib/asana_export_importer/AsanaApiExt.js
+++ b/lib/asana_export_importer/AsanaApiExt.js
@@ -8,6 +8,10 @@ aei.asana.resources.Projects.prototype.addFollowers = function(projectId, data) 
     return this.dispatcher.post('/projects/' + projectId + '/addFollowers', data);
 };
 
+aei.asana.resources.Projects.prototype.addCustomFieldSetting = function(projectId, data) {
+    return this.dispatcher.post('/projects/' + projectId + '/addCustomFieldSetting', data);
+};
+
 aei.asana.resources.Tasks.prototype.findByWorkspace = function(workspaceId, params) {
     return this.dispatcher.get('/workspaces/' + workspaceId + '/tasks', params);
 };

--- a/lib/asana_export_importer/Importer.js
+++ b/lib/asana_export_importer/Importer.js
@@ -13,6 +13,7 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
 
     _runImport: function() {
         this._importTeams();
+        this._importCustomFieldProtos();
         this._importProjects();
         this._importColumns();
         this._importTags();
@@ -43,6 +44,13 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
             team.setOrganizationId(this.organizationId());
             team.create();
         }, "importing teams");
+    },
+
+    _importCustomFieldProtos: function() {
+        this._forEachOfType("customFieldProto", function(customFieldProto) {
+            customFieldProto.setWorkspaceId(this.organizationId());
+            customFieldProto.create();
+        }, "importing custom field protos");
     },
 
     _importProjects: function() {

--- a/lib/asana_export_importer/Importer.js
+++ b/lib/asana_export_importer/Importer.js
@@ -15,6 +15,7 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
         this._importTeams();
         this._importCustomFieldProtos();
         this._importProjects();
+        this._addCustomFieldSettingsToProjects();
         this._importColumns();
         this._importTags();
 
@@ -25,9 +26,9 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
         this._addSubtasksToTasks();
         this._addDependenciesToTasks();
         this._addTasksToProjects();
+        this._addCustomFieldValuesToTasks();
         this._addTasksToTags();
         this._addTasksToColumns();
-        this._addCustomFieldSettingsToProjects();
 
         this._importUsers();
 
@@ -62,6 +63,12 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
                 project.create();
             }
         }, "importing projects");
+    },
+
+    _addCustomFieldSettingsToProjects: function() {
+        this._forEachOfType("project", function(project) {
+            project.addCustomFieldSettings();
+        }, "adding custom field settings to projects");
     },
 
     _importColumns: function() {
@@ -153,18 +160,19 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
         this._forEachOfType("project", this._addItemsToObject, "adding tasks to projects");
     },
 
+    _addCustomFieldValuesToTasks: function() {
+        var self = this;
+        this._forEachOfType("task", function(task) {
+            task.addCustomFieldValues();
+        }, "adding custom field values to tasks");
+    },
+
     _addTasksToTags: function() {
         this._forEachOfType("tag", this._addItemsToObject, "adding tasks to tags");
     },
 
     _addTasksToColumns: function() {
         this._forEachOfType("column", this._addItemsToObject, "adding tasks to columns");
-    },
-
-    _addCustomFieldSettingsToProjects: function() {
-        this._forEachOfType("project", function(project) {
-            project.addCustomFieldSettings();
-        }, "adding custom field settings to projects");
     },
 
     _addAssigneesToTasks: function() {

--- a/lib/asana_export_importer/Importer.js
+++ b/lib/asana_export_importer/Importer.js
@@ -27,6 +27,7 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
         this._addTasksToProjects();
         this._addTasksToTags();
         this._addTasksToColumns();
+        this._addCustomFieldSettingsToProjects();
 
         this._importUsers();
 
@@ -158,6 +159,12 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
 
     _addTasksToColumns: function() {
         this._forEachOfType("column", this._addItemsToObject, "adding tasks to columns");
+    },
+
+    _addCustomFieldSettingsToProjects: function() {
+        this._forEachOfType("project", function(project) {
+            project.addCustomFieldSettings();
+        }, "adding custom field settings to projects");
     },
 
     _addAssigneesToTasks: function() {

--- a/lib/asana_export_importer/MockExport.js
+++ b/lib/asana_export_importer/MockExport.js
@@ -3,6 +3,7 @@ var aei = require("./");
 var MockExportData = aei.ideal.Proto.extend().setType("MockExportData").newSlots({
     users: [],
     teams: [],
+    customFieldProtos: [],
     projects: [],
     tags: [],
     tasks: [],
@@ -36,6 +37,12 @@ var MockExport = module.exports =  aei.Export.extend().newSlots({
     teams: function() {
         return this.data().teams().map(function(team) {
             return aei.Team.clone().performSets(team)
+        });
+    },
+
+    customFieldProtos: function() {
+        return this.data().customFieldProtos().map(function(customFieldProto) {
+            return aei.CustomFieldProto.clone().performSets(customFieldProto);
         });
     },
 

--- a/lib/asana_export_importer/index.js
+++ b/lib/asana_export_importer/index.js
@@ -20,6 +20,7 @@ module.exports.asana = require("asana");
     "models/ImportObject",
     "models/Attachment",
     "models/Column",
+    "models/CustomFieldProto",
     "models/Project",
     "models/Tag",
     "models/Task",

--- a/lib/asana_export_importer/models/CustomFieldProto.js
+++ b/lib/asana_export_importer/models/CustomFieldProto.js
@@ -15,9 +15,15 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
     precision: null, // null if type is not "number"
     options: null // null if type if type is not "enum" TODO otherwise, what is this????
 }).setSlots({
+    _createResource: function(resourceData) {
+        // The current version of the Asana node client library is not aware of CustomFieldProtos, so we have to do it manually
+        var dispatcher = this.app().apiClient().dispatcher;
 
+        return aei.Future.withPromise(dispatcher.post('/custom_fields', resourceData)).wait();
+    },
     _resourceData: function() {
         var data = {
+            workspace: this.workspaceId(),
             name: this.name(),
             // TODO description
             type: this.type()

--- a/lib/asana_export_importer/models/CustomFieldProto.js
+++ b/lib/asana_export_importer/models/CustomFieldProto.js
@@ -14,7 +14,9 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
     description: null,
     type: null,
     precision: null, // null if type is not "number"
-    options: null // null if type if type is not "enum" TODO otherwise, what is this????
+    // null if type if type is not "enum"
+    // otherwise, [ { name:.., enabled:.., color:.. }, ...] (ordered)
+    options: null
 }).setSlots({
     _createResource: function(resourceData) {
         var self = this;
@@ -60,7 +62,7 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
         if (this.type() === "number") {
             data.precision = this.precision();
         } else if (this.type() === "enum") {
-            data.enum_options = []; // TODO translate from intermediate representation?
+            data.enum_options = this.options();
         }
 
         return data;

--- a/lib/asana_export_importer/models/CustomFieldProto.js
+++ b/lib/asana_export_importer/models/CustomFieldProto.js
@@ -15,7 +15,7 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
     type: null,
     precision: null, // null if type is not "number"
     // null if type if type is not "enum"
-    // otherwise, [ { name:.., enabled:.., color:.. }, ...] (ordered)
+    // otherwise, [ { sourceId:.., name:.., enabled:.., color:.. }, ...] (ordered)
     options: null
 }).setSlots({
     _createResource: function(resourceData) {
@@ -48,6 +48,18 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
             resourceData.name = resourceData.name + " (Imported " + uniqueString + ")";
             response = aei.Future.withPromise(dispatcher.post('/custom_fields', resourceData)).wait();
         }
+
+        if (self.type() === "enum") {
+            // Enum options are created during the creation of the enum proto.
+            // However, we need their IDs, to reference them in values later.
+            // So we manually parse the response from the API, which contains the
+            // new asana ID, and write that to the sourceToAsanaMap manually.
+            response.enum_options.forEach(function(apiOption, i) {
+                var exportOption = self.options()[i];
+                self.app().sourceToAsanaMap().atPut(exportOption.sourceId, apiOption.id);
+            });
+        }
+
         return response;
     },
 

--- a/lib/asana_export_importer/models/CustomFieldProto.js
+++ b/lib/asana_export_importer/models/CustomFieldProto.js
@@ -45,8 +45,15 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
                 uniqueString = new Date().getTime();
             }
 
-            resourceData.name = resourceData.name + " (Imported " + uniqueString + ")";
-            response = aei.Future.withPromise(dispatcher.post('/custom_fields', resourceData)).wait();
+            // Do this the hard way or the mockers in testing will be confused
+            var amendedResourceData = {
+                name: resourceData.name + " (Imported " + uniqueString + ")",
+                workspace: resourceData.workspace,
+                type: resourceData.type,
+                precision: resourceData.precision,
+                enum_options: resourceData.enum_options
+            };
+            response = aei.Future.withPromise(dispatcher.post('/custom_fields', amendedResourceData)).wait();
         }
 
         if (self.type() === "enum") {

--- a/lib/asana_export_importer/models/CustomFieldProto.js
+++ b/lib/asana_export_importer/models/CustomFieldProto.js
@@ -1,4 +1,5 @@
 var aei = require("../");
+var fs = require("fs");
 
 /**
  * This represents all three kinds of custom field, because subclassing
@@ -16,11 +17,38 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
     options: null // null if type if type is not "enum" TODO otherwise, what is this????
 }).setSlots({
     _createResource: function(resourceData) {
+        var self = this;
         // The current version of the Asana node client library is not aware of CustomFieldProtos, so we have to do it manually
         var dispatcher = this.app().apiClient().dispatcher;
 
-        return aei.Future.withPromise(dispatcher.post('/custom_fields', resourceData)).wait();
+        var response;
+
+        // First, try with the original name
+        try {
+            response = aei.Future.withPromise(dispatcher.post('/custom_fields', resourceData)).wait();
+        } catch (ex) {
+            // If that fails, there must already be a custom field with that name.
+            // Add some unique string to the name and try again.
+            var uniqueString;
+            if (self.app().apiClient().dbPath) {
+                // Hack: If available, we choose the inode number
+                // of the sqlite db file containing the cache, because that will remain
+                // the same as long as the cache is intact, and will be new for completely
+                // separate import attempts.
+                var dbPath = self.app().apiClient().dbPath();
+                uniqueString = aei.Future.wrap(function (callback) {
+                    fs.stat(dbPath, callback);
+                })().wait().ino;
+            } else {
+                uniqueString = new Date().getTime();
+            }
+
+            resourceData.name = resourceData.name + " (Imported " + uniqueString + ")";
+            response = aei.Future.withPromise(dispatcher.post('/custom_fields', resourceData)).wait();
+        }
+        return response;
     },
+
     _resourceData: function() {
         var data = {
             workspace: this.workspaceId(),

--- a/lib/asana_export_importer/models/CustomFieldProto.js
+++ b/lib/asana_export_importer/models/CustomFieldProto.js
@@ -48,6 +48,7 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
             // Do this the hard way or the mockers in testing will be confused
             var amendedResourceData = {
                 name: resourceData.name + " (Imported " + uniqueString + ")",
+                description: resourceData.description,
                 workspace: resourceData.workspace,
                 type: resourceData.type,
                 precision: resourceData.precision,
@@ -74,7 +75,7 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
         var data = {
             workspace: this.workspaceId(),
             name: this.name(),
-            // TODO description
+            description: this.description(),
             type: this.type()
         };
 

--- a/lib/asana_export_importer/models/CustomFieldProto.js
+++ b/lib/asana_export_importer/models/CustomFieldProto.js
@@ -1,0 +1,34 @@
+var aei = require("../");
+
+/**
+ * This represents all three kinds of custom field, because subclassing
+ * would cause more complexity than it would save.
+ */
+var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
+    type: "CustomFieldProto",
+    resourceName: "custom_fields"
+}).newSlots({
+    workspaceId: null,
+    name: null,
+    description: null,
+    type: null,
+    precision: null, // null if type is not "number"
+    options: null // null if type if type is not "enum" TODO otherwise, what is this????
+}).setSlots({
+
+    _resourceData: function() {
+        var data = {
+            name: this.name(),
+            // TODO description
+            type: this.type()
+        };
+
+        if (this.type() === "number") {
+            data.precision = this.precision();
+        } else if (this.type() === "enum") {
+            data.enum_options = []; // TODO translate from intermediate representation?
+        }
+
+        return data;
+    }
+});

--- a/lib/asana_export_importer/models/Project.js
+++ b/lib/asana_export_importer/models/Project.js
@@ -15,7 +15,7 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
     sourceItemIds: null,
     sourceMemberIds: null,
     sourceFollowerIds: null,
-    // [ { sourceCustomFieldId:.., isImportant:.. } ] (ordered)
+    // [ { sourceCustomFieldProtoId:.., isImportant:.. } ] (ordered)
     customFieldSettings: null,
     asanaTeamId: null
 }).setSlots({
@@ -33,8 +33,16 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
         })).wait();
     },
 
-    addCustomFieldSettings: function() { //TODO how to map to asana IDs for each setting???
+    addCustomFieldSettings: function() {
+        var self = this;
+        var sourceToAsanaMap = self.app().sourceToAsanaMap();
 
+        self.customFieldSettings().forEach(function(customFieldSetting) {
+            aei.Future.withPromise(self._resource().addCustomFieldSetting(self.asanaId(), {
+               custom_field: sourceToAsanaMap.at(customFieldSetting.sourceCustomFieldProtoId),
+               is_important: customFieldSetting.isImportant
+           })).wait();
+        });
     },
 
     addItem: function(taskId) {

--- a/lib/asana_export_importer/models/Project.js
+++ b/lib/asana_export_importer/models/Project.js
@@ -15,6 +15,8 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
     sourceItemIds: null,
     sourceMemberIds: null,
     sourceFollowerIds: null,
+    // [ { sourceCustomFieldId:.., isImportant:.. } ] (ordered)
+    customFieldSettings: null,
     asanaTeamId: null
 }).setSlots({
     addMembers: function(memberAsanaIds) {
@@ -29,6 +31,10 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
             followers: followerAsanaIds,
             silent: true
         })).wait();
+    },
+
+    addCustomFieldSettings: function() { //TODO how to map to asana IDs for each setting???
+
     },
 
     addItem: function(taskId) {

--- a/lib/asana_export_importer/models/Task.js
+++ b/lib/asana_export_importer/models/Task.js
@@ -17,7 +17,9 @@ var Task = module.exports = aei.ImportObject.extend().performSets({
     sourceBlockingTaskIds: null,
     stories: null,
     recurrenceType: null,
-    recurrenceData: null
+    recurrenceData: null,
+    // [ { protoSourceId:.., value: string|number|sourceEnumOptionID, type: "text"|"number"|"enum" }, ...]
+    customFieldValues: null
 }).setSlots({
     addItem: function(itemId) {
         return aei.Future.withPromise(this._resource().setParent(itemId, {
@@ -52,6 +54,26 @@ var Task = module.exports = aei.ImportObject.extend().performSets({
     addBlockingTasks: function(blockingTaskAsanaIds) {
         return aei.Future.withPromise(this._resourceNamed("tasks").update(this.asanaId(), {
             tasks_blocking_this: blockingTaskAsanaIds
+        })).wait();
+    },
+
+    addCustomFieldValues: function() {
+        var sourceToAsanaMap = this.app().sourceToAsanaMap();
+        var customFields = {};
+        this.customFieldValues().forEach(function(fieldValue) {
+            var protoAsanaId = sourceToAsanaMap.at(fieldValue.protoSourceId);
+            var valueToSend = fieldValue.value;
+
+            if (fieldValue.type === "enum") {
+                // Only enum values need a translation, to the asanaId of the correct option
+                valueToSend = sourceToAsanaMap.at(valueToSend);
+            }
+            customFields[protoAsanaId] = valueToSend;
+        });
+
+        // TODO if we can't add orphaned values, at least do these one at a time so they can fail independently
+        return aei.Future.withPromise(this._resourceNamed("tasks").update(this.asanaId(), {
+            custom_fields: customFields
         })).wait();
     },
 

--- a/lib/asana_export_importer/models/Task.js
+++ b/lib/asana_export_importer/models/Task.js
@@ -76,9 +76,10 @@ var Task = module.exports = aei.ImportObject.extend().performSets({
             customFields[protoAsanaId] = valueToSend;
         });
 
-        // TODO if we can't add orphaned values, at least do these one at a time so they can fail independently
         return aei.Future.withPromise(this._resourceNamed("tasks").update(this.asanaId(), {
-            custom_fields: customFields
+            custom_fields: customFields,
+            // Allows us to create orphaned custom fields, where no project containing the task has the field
+            force_write_custom_fields: true
         })).wait();
     },
 

--- a/lib/asana_export_importer/models/Task.js
+++ b/lib/asana_export_importer/models/Task.js
@@ -58,6 +58,11 @@ var Task = module.exports = aei.ImportObject.extend().performSets({
     },
 
     addCustomFieldValues: function() {
+        if (this.customFieldValues().length === 0) {
+            // No need to wait for the API call
+            return;
+        }
+
         var sourceToAsanaMap = this.app().sourceToAsanaMap();
         var customFields = {};
         this.customFieldValues().forEach(function(fieldValue) {

--- a/test/integration.js
+++ b/test/integration.js
@@ -83,13 +83,13 @@ describe("Integration", function() {
             expect(client.dispatcher.post).to.have.callCount(2);
             expect(client.dispatcher.post).to.have.been.calledWithExactly("/custom_fields", {
                 name: "Teddy",
-                // description: "A text field", TODO
+                description: "A text field",
                 type: "text",
                 workspace: orgId
             });
             expect(client.dispatcher.post).to.have.been.calledWithExactly("/custom_fields", {
                 name: "Noddy",
-                // description: "A number field", TODO
+                description: "A number field",
                 type: "number",
                 precision: 3,
                 workspace: orgId
@@ -129,7 +129,7 @@ describe("Integration", function() {
             expect(client.dispatcher.post).to.have.callCount(1);
             expect(client.dispatcher.post).to.have.been.calledWithExactly("/custom_fields", {
                 name: "Eddy",
-                // description: "A enum field", TODO
+                description: "A enum field",
                 type: "enum",
                 workspace: orgId,
                 enum_options: [
@@ -167,7 +167,7 @@ describe("Integration", function() {
             // First attempt with name "Teddy"
             expect(client.dispatcher.post).to.have.been.calledWithExactly("/custom_fields", {
                 name: "Teddy",
-                // description: "A text field", TODO
+                description: "A text field",
                 type: "text",
                 workspace: orgId
             });
@@ -175,7 +175,7 @@ describe("Integration", function() {
             // Second attempt with name like "Teddy (Imported 12345)"
             expect(client.dispatcher.post).to.have.been.calledWithMatch("/custom_fields", {
                 name: sinon.match(/Teddy \(Imported .*\)/),
-                // description: "A number field", TODO
+                description: "A text field",
                 type: "text",
                 workspace: orgId
             });
@@ -695,14 +695,16 @@ describe("Integration", function() {
             var task1CustomFields = {};
             task1CustomFields[app.sourceToAsanaMap().at(100)] = "Yo";
             client.tasks.update.should.have.been.calledWithExactly(app.sourceToAsanaMap().at(300), {
-                custom_fields: task1CustomFields
+                custom_fields: task1CustomFields,
+                force_write_custom_fields: true
             });
 
             var task2CustomFields = {};
             task2CustomFields[app.sourceToAsanaMap().at(101)] = "3.142";
             task2CustomFields[app.sourceToAsanaMap().at(102)] = app.sourceToAsanaMap().at(104);
             client.tasks.update.should.have.been.calledWithExactly(app.sourceToAsanaMap().at(301), {
-                custom_fields: task2CustomFields
+                custom_fields: task2CustomFields,
+                force_write_custom_fields: true
             });
         });
     });

--- a/test/integration.js
+++ b/test/integration.js
@@ -87,7 +87,7 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.projects().mapPerform("toJS")).to.deep.equal([
-                { sourceId: 200, name: "project1", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [] }
+                { sourceId: 200, name: "project1", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [], customFieldSettings: [] }
             ]);
 
             importer._importTeams();
@@ -106,9 +106,9 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.projects().mapPerform("toJS")).to.deep.equal([
-                { sourceId: 200, name: "project1", notes: "desc", archived: false, public: true, color: null, isBoard: false, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [] },
-                { sourceId: 201, name: "project2", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [] },
-                { sourceId: 202, name: "project3", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [] }
+                { sourceId: 200, name: "project1", notes: "desc", archived: false, public: true, color: null, isBoard: false, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [], customFieldSettings: [] },
+                { sourceId: 201, name: "project2", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [], customFieldSettings: [] },
+                { sourceId: 202, name: "project3", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 100, sourceItemIds: [], sourceMemberIds: [], sourceFollowerIds: [], customFieldSettings: [] }
             ]);
 
             importer._importTeams();
@@ -224,8 +224,8 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.taskDataSource()(0,50).mapPerform("toJS")).to.deep.equal([
-                { sourceId: 100, name: "task1", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nSun Nov 16 2014"], recurrenceData: null, recurrenceType: null },
-                { sourceId: 101, name: "task2", notes: "desc", completed: true, dueOn: "2023-11-30 00:00:00", public: false, assigneeStatus: "upcoming", sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nSun Nov 16 2014"], recurrenceData: null, recurrenceType: null }
+                { sourceId: 100, name: "task1", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nSun Nov 16 2014"], recurrenceData: null, recurrenceType: null, customFieldValues: [] },
+                { sourceId: 101, name: "task2", notes: "desc", completed: true, dueOn: "2023-11-30 00:00:00", public: false, assigneeStatus: "upcoming", sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nSun Nov 16 2014"], recurrenceData: null, recurrenceType: null, customFieldValues: [] }
             ]);
 
             importer._importTasks();
@@ -253,9 +253,9 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.taskDataSource()(0,50).mapPerform("toJS")).to.deep.equal([
-                { sourceId: 100, name: "task1", notes: "", completed: false, dueOn: null, public: true, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null },
-                { sourceId: 101, name: "task2", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null },
-                { sourceId: 102, name: "task3", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null }
+                { sourceId: 100, name: "task1", notes: "", completed: false, dueOn: null, public: true, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: [] },
+                { sourceId: 101, name: "task2", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: [] },
+                { sourceId: 102, name: "task3", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: [] }
             ]);
 
             importer._importTasks();
@@ -273,9 +273,9 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.taskDataSource()(0,50).mapPerform("toJS")).to.deep.equal([
-                { sourceId: 100, name: "task1", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: "NEVER" },
-                { sourceId: 101, name: "task2", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: "{\"days_after_completion\":4,\"original_due_date\":1418342400000}", recurrenceType: "PERIODICALLY" },
-                { sourceId: 102, name: "task3", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: "{\"days_of_week\":[3,5],\"original_due_date\":1418342400000}", recurrenceType: "WEEKLY" }
+                { sourceId: 100, name: "task1", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: "NEVER", customFieldValues: [] },
+                { sourceId: 101, name: "task2", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: "{\"days_after_completion\":4,\"original_due_date\":1418342400000}", recurrenceType: "PERIODICALLY", customFieldValues: [] },
+                { sourceId: 102, name: "task3", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: "{\"days_of_week\":[3,5],\"original_due_date\":1418342400000}", recurrenceType: "WEEKLY", customFieldValues: [] }
             ]);
 
             importer._importTasks();
@@ -302,7 +302,7 @@ describe("Integration", function() {
 
             expect(exp.taskDataSource()(0,50).mapPerform("toJS")).to.deep.equal([
                 {
-                    sourceId: 300, name: "task1", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], recurrenceData: null, recurrenceType: null,  stories: [
+                    sourceId: 300, name: "task1", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], recurrenceData: null, recurrenceType: null, customFieldValues: [],  stories: [
                         "created task.\nThu Jan 01 1970",
                         "user1\ncomment1\nMon Nov 17 2014",
                         "user1\ncomment2\nMon Nov 17 2014"
@@ -365,9 +365,9 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.taskDataSource()(0,50).mapPerform("toJS")).to.deep.equal([
-                { sourceId: 100, name: "task1",    notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [202, 201], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null  },
-                { sourceId: 201, name: "subtask2", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [],         sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null  },
-                { sourceId: 202, name: "subtask3", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [],         sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null  }
+                { sourceId: 100, name: "task1",    notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [202, 201], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: []  },
+                { sourceId: 201, name: "subtask2", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [],         sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: []  },
+                { sourceId: 202, name: "subtask3", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [],         sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: []  }
             ]);
 
             importer._importTasks();
@@ -392,8 +392,8 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.taskDataSource()(0,50).mapPerform("toJS")).to.deep.equal([
-                { sourceId: 100, name: "precedent", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null  },
-                { sourceId: 101, name: "dependent", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [100], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null  }
+                { sourceId: 100, name: "precedent", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: []  },
+                { sourceId: 101, name: "dependent", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [100], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: []  }
             ]);
 
             importer._importTasks();
@@ -421,7 +421,7 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.projects().mapPerform("toJS")).to.deep.equal([
-                { sourceId: 200, name: "project1", notes: "desc", sourceTeamId: 100, sourceMemberIds: [], sourceItemIds: [301, 300], sourceFollowerIds: [], archived: false, color: null, isBoard: false, public: false }
+                { sourceId: 200, name: "project1", notes: "desc", sourceTeamId: 100, sourceMemberIds: [], sourceItemIds: [301, 300], sourceFollowerIds: [], archived: false, color: null, isBoard: false, public: false, customFieldSettings: [] }
             ]);
 
             importer._importTeams();
@@ -606,10 +606,10 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.taskDataSource()(0,50).mapPerform("toJS")).to.deep.equal([
-                { sourceId: 300, name: "task1", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: "upcoming", sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null },
-                { sourceId: 301, name: "task2", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: "upcoming", sourceAssigneeId: 100, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null },
-                { sourceId: 302, name: "task3", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: "later", sourceAssigneeId: 100, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null },
-                { sourceId: 303, name: "task4", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: "today", sourceAssigneeId: 100, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null },
+                { sourceId: 300, name: "task1", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: "upcoming", sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: [] },
+                { sourceId: 301, name: "task2", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: "upcoming", sourceAssigneeId: 100, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: [] },
+                { sourceId: 302, name: "task3", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: "later", sourceAssigneeId: 100, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: [] },
+                { sourceId: 303, name: "task4", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: "today", sourceAssigneeId: 100, sourceItemIds: [], sourceFollowerIds: [], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: [] },
             ]);
 
             importer._importTasks();
@@ -635,7 +635,7 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.taskDataSource()(0,50).mapPerform("toJS")).to.deep.equal([
-                { sourceId: 300, name: "task1", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [100, 101], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null  }
+                { sourceId: 300, name: "task1", notes: "", completed: false, dueOn: null, public: false, assigneeStatus: null, sourceAssigneeId: null, sourceItemIds: [], sourceFollowerIds: [100, 101], sourceBlockingTaskIds: [], stories: ["created task.\nThu Jan 01 1970"], recurrenceData: null, recurrenceType: null, customFieldValues: []  }
             ]);
 
             importer._importTasks();
@@ -726,7 +726,7 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.projects().mapPerform("toJS")).to.deep.equal([
-                { sourceId: 400, name: "project1", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 300, sourceItemIds: [], sourceFollowerIds: [], sourceMemberIds: [100, 101] }
+                { sourceId: 400, name: "project1", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 300, sourceItemIds: [], sourceFollowerIds: [], sourceMemberIds: [100, 101], customFieldSettings: [] }
             ]);
 
             importer._importTeams();
@@ -763,7 +763,7 @@ describe("Integration", function() {
             exp.prepareForImport();
 
             expect(exp.projects().mapPerform("toJS")).to.deep.equal([
-                { sourceId: 400, name: "project1", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 300, sourceItemIds: [], sourceFollowerIds: [100, 101], sourceMemberIds: [100, 101] }
+                { sourceId: 400, name: "project1", notes: "desc", archived: false, public: false, color: null, isBoard: false, sourceTeamId: 300, sourceItemIds: [], sourceFollowerIds: [100, 101], sourceMemberIds: [100, 101], customFieldSettings: [] }
             ]);
 
             importer._importTeams();


### PR DESCRIPTION
Sorry this is a huge diff.

A lot is just plumbing. A lot is pretty straighforwardly pushing data around.

The most interesting decisions are in:
CustomFieldProto.js - where there is a retry mechanism for when a field of the same name already exists. And I decided to call the asana API directly via the dispatcher, rather than upgrade to an API client which has support for custom fields. Just because that'd be more work.
