### PR TITLE
Alexd fix cf issues

### DIFF
--- a/lib/asana_export_importer/models/CustomFieldProto.js
+++ b/lib/asana_export_importer/models/CustomFieldProto.js
@@ -63,9 +63,15 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
             // However, we need their IDs, to reference them in values later.
             // So we manually parse the response from the API, which contains the
             // new asana ID, and write that to the sourceToAsanaMap manually.
-            response.enum_options.forEach(function(apiOption, i) {
-                var exportOption = self.options()[i];
-                self.app().sourceToAsanaMap().atPut(exportOption.sourceId, apiOption.id);
+            self.options().forEach(function(exportOption, i) {
+                // Check whether the option is already in the map before looking up
+                // in the API response. If this is a re-run, and the response was
+                // returned by the cache, it doesn't contain the option IDs, but
+                // the previous run will have already put them in the map.
+                if (self.app().sourceToAsanaMap().at(exportOption.sourceId) === null) {
+                    var apiOption = response.enum_options[i];
+                    self.app().sourceToAsanaMap().atPut(exportOption.sourceId, apiOption.id);
+                }
             });
         }
 

--- a/lib/asana_export_importer/models/Project.js
+++ b/lib/asana_export_importer/models/Project.js
@@ -38,10 +38,15 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
         var sourceToAsanaMap = self.app().sourceToAsanaMap();
 
         self.customFieldSettings().forEach(function(customFieldSetting) {
-            aei.Future.withPromise(self._resource().addCustomFieldSetting(self.asanaId(), {
-               custom_field: sourceToAsanaMap.at(customFieldSetting.sourceCustomFieldProtoId),
-               is_important: customFieldSetting.isImportant
-           })).wait();
+            var customFieldProtoAsanaId = sourceToAsanaMap.at(customFieldSetting.sourceCustomFieldProtoId);
+
+            // Skip if the proto wasn't imported, because we assume it was trashed in the export
+            if (customFieldProtoAsanaId !== null) {
+                aei.Future.withPromise(self._resource().addCustomFieldSetting(self.asanaId(), {
+                    custom_field: customFieldProtoAsanaId,
+                    is_important: customFieldSetting.isImportant
+                })).wait();
+            }
         });
     },
 

--- a/lib/asana_export_importer/models/Task.js
+++ b/lib/asana_export_importer/models/Task.js
@@ -68,13 +68,17 @@ var Task = module.exports = aei.ImportObject.extend().performSets({
         var customFields = {};
         this.customFieldValues().forEach(function(fieldValue) {
             var protoAsanaId = sourceToAsanaMap.at(fieldValue.protoSourceId);
-            var valueToSend = fieldValue.value;
 
-            if (fieldValue.type === "enum") {
-                // Only enum values need a translation, to the asanaId of the correct option
-                valueToSend = sourceToAsanaMap.at(valueToSend);
+            // Skip if the proto wasn't imported, because we assume it was trashed in the export
+            if (protoAsanaId !== null) {
+                var valueToSend = fieldValue.value;
+
+                if (fieldValue.type === "enum") {
+                    // Only enum values need a translation, to the asanaId of the correct option
+                    valueToSend = sourceToAsanaMap.at(valueToSend);
+                }
+                customFields[protoAsanaId] = valueToSend;
             }
-            customFields[protoAsanaId] = valueToSend;
         });
 
         return aei.Future.withPromise(this._resourceNamed("tasks").update(this.asanaId(), {


### PR DESCRIPTION
Don't try to read enum CF option IDs from the API response when we already know then, because we're getting an API response from the cache, and it won't contain that information

Skip over custom field settings and values when the corresponding proto is trashed. And tests for both