### PR TITLE
Skip over adding tasks to columns in trashed pots

### DIFF
--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -254,7 +254,12 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
 
     columns: function() {
         var self = this;
-        return self.db().findByType("Column").sort(function(columnA, columnB) {
+        return self.db().findByType("Column").filter(function(column) {
+            var pot  = self.db().findById(column.pot);
+            // If the pot is missing, it was probably trashed in the export, and so we should skip all its
+            // columns, including (importantly) adding tasks to them.
+            return pot !== undefined;
+        }).sort(function(columnA, columnB) {
             return columnA.rank.localeCompare(columnB.rank);
         }).map(function(obj) {
             var tasks = self.db().findOrderedChildrenByType("column_task", obj.__object_id, "Task").map(function(task) {

--- a/lib/asana_export_importer/models/Column.js
+++ b/lib/asana_export_importer/models/Column.js
@@ -19,6 +19,12 @@ var Column = module.exports = aei.ImportObject.extend().performSets({
 
     // Adds a task at the top of the column
     addItem: function(taskAsanaId) {
+        if (this.asanaId() === null) {
+            // (Ugly) This column was never created. Probably part of a trashed pot.
+            // Don't add tasks to it
+            return;
+        }
+
         // The current version of the Asana node client library is not aware of Columns, so we have to do it manually
         var path = util.format('/columns/%s/addTask', this.asanaId());
         var dispatcher = this.app().apiClient().dispatcher;

--- a/lib/asana_export_importer/models/Column.js
+++ b/lib/asana_export_importer/models/Column.js
@@ -19,12 +19,6 @@ var Column = module.exports = aei.ImportObject.extend().performSets({
 
     // Adds a task at the top of the column
     addItem: function(taskAsanaId) {
-        if (this.asanaId() === null) {
-            // (Ugly) This column was never created. Probably part of a trashed pot.
-            // Don't add tasks to it
-            return;
-        }
-
         // The current version of the Asana node client library is not aware of Columns, so we have to do it manually
         var path = util.format('/columns/%s/addTask', this.asanaId());
         var dispatcher = this.app().apiClient().dispatcher;

--- a/test/asana_export/AsanaExport.js
+++ b/test/asana_export/AsanaExport.js
@@ -139,26 +139,30 @@ describe("AsanaExport", function() {
         });
 
         it("should return a column containing some tasks", function() {
-            exp.addObject(1, "Column", { name: "First column", pot: 12345, rank: "V" });
-            exp.addObject(2, "ColumnTask", { column: 1, pot: 12345, task: 10, rank: "a" });
-            exp.addObject(3, "ColumnTask", { column: 1, pot: 12345, task: 12, rank: "c" });
-            exp.addObject(4, "ColumnTask", { column: 1, pot: 12345, task: 11, rank: "b" });
+            exp.addObject(20, "Team", { name: "team1", team_type: "REQUEST_TO_JOIN" });
+            exp.addObject(21, "ItemList", { followers_du: [], name: "project1", description: "description", is_project: true, is_archived: false, items: [10,11,12], team: 20, stories: [] });
+            exp.addObject(1, "Column", { name: "First column", pot: 21, rank: "V" });
+            exp.addObject(2, "ColumnTask", { column: 1, pot: 21, task: 10, rank: "a" });
+            exp.addObject(3, "ColumnTask", { column: 1, pot: 21, task: 12, rank: "c" });
+            exp.addObject(4, "ColumnTask", { column: 1, pot: 21, task: 11, rank: "b" });
             exp.addObject(10, "Task", { });
             exp.addObject(11, "Task", { });
             exp.addObject(12, "Task", { });
             exp.prepareForImport();
 
             exp.columns().mapPerform("performGets", ["sourceId", "name", "sourceProjectId", "sourceItemIds"]).should.deep.equal([
-                { sourceId: 1, name: "First column", sourceProjectId: 12345, sourceItemIds: [10,11,12] }
+                { sourceId: 1, name: "First column", sourceProjectId: 21, sourceItemIds: [10,11,12] }
             ]);
         });
 
         it("should give name to a column with empty name", function() {
-            exp.addObject(1, "Column", { name: "", pot: 12345, rank: "V" });
+            exp.addObject(20, "Team", { name: "team1", team_type: "REQUEST_TO_JOIN" });
+            exp.addObject(21, "ItemList", { followers_du: [], name: "project1", description: "description", is_project: true, is_archived: false, items: [10,11,12], team: 20, stories: [] });
+            exp.addObject(1, "Column", { name: "", pot: 21, rank: "V" });
             exp.prepareForImport();
 
             exp.columns().mapPerform("performGets", ["sourceId", "name", "sourceProjectId", "sourceItemIds"]).should.deep.equal([
-                { sourceId: 1, name: "Unnamed column", sourceProjectId: 12345, sourceItemIds: [] }
+                { sourceId: 1, name: "Unnamed column", sourceProjectId: 21, sourceItemIds: [] }
             ]);
         });
     });
@@ -171,9 +175,12 @@ describe("AsanaExport", function() {
         });
 
         it("should group columns by project and be in correct order by rank", function() {
-            exp.addObject(1, "Column", { name: "First column", pot: 12345, rank: "a" });
-            exp.addObject(2, "Column", { name: "Third column", pot: 12345, rank: "c" });
-            exp.addObject(3, "Column", { name: "Second column", pot: 12345, rank: "b" });
+            exp.addObject(20, "Team", { name: "team1", team_type: "REQUEST_TO_JOIN" });
+            exp.addObject(21, "ItemList", { followers_du: [], name: "project1", description: "description", is_project: true, is_archived: false, items: [10,11,12], team: 20, stories: [] });
+            exp.addObject(23, "ItemList", { followers_du: [], name: "project1", description: "description", is_project: true, is_archived: false, items: [10,11,12], team: 20, stories: [] });
+            exp.addObject(1, "Column", { name: "First column", pot: 21, rank: "a" });
+            exp.addObject(2, "Column", { name: "Third column", pot: 21, rank: "c" });
+            exp.addObject(3, "Column", { name: "Second column", pot: 21, rank: "b" });
             exp.addObject(4, "Column", { name: "Other project column", pot: 23, rank: "b" });
             exp.prepareForImport();
 
@@ -181,7 +188,7 @@ describe("AsanaExport", function() {
 
             Object.keys(columnsBySourceProjectId).length.should.equal(2);
 
-            columnsBySourceProjectId[12345].mapPerform("performGets", ["sourceId", "name"]).should.deep.equal([
+            columnsBySourceProjectId[21].mapPerform("performGets", ["sourceId", "name"]).should.deep.equal([
                 { sourceId: 1, name: "First column" },
                 { sourceId: 3, name: "Second column" },
                 { sourceId: 2, name: "Third column" }


### PR DESCRIPTION
The neatest way to do this is to skip the columns in the trashed pots altogether. The bug was during adding tasks to columns, but that was an accident of the way columns are added to each project in turn, so columns in a trashed project existed, but were not touched until adding tasks to them.

Also added a test and adapted some others to cope