### PR TITLE
Support import custom fields that are not published to the domain

### DIFF
--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -177,6 +177,23 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
 
     customFieldProtos: function() {
         var self = this;
+        var textProtos = self.db().findByType("CustomPropertyTextProto").map(function(obj) {
+            return self._createCustomFieldProto(obj);
+        });
+
+        var numberProtos = self.db().findByType("CustomPropertyNumberProto").map(function(obj) {
+            return self._createCustomFieldProto(obj);
+        });
+
+        var enumProtos = self.db().findByType("CustomPropertyEnumProto").map(function(obj) {
+            return self._createCustomFieldProto(obj);
+        });
+
+        return textProtos.concat(numberProtos, enumProtos).emptiesRemoved();
+    },
+
+    _createCustomFieldProto: function(obj) {
+        var self = this;
         var createBasicCustomFieldProto = function(obj) {
             return ae.aei.CustomFieldProto.clone().performSets({
                 sourceId: obj.__object_id,
@@ -187,20 +204,20 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
             });
         };
 
-        var textProtos = self.db().findByType("CustomPropertyTextProto").map(function(obj) {
+        var createTextProto = function(obj) {
             return createBasicCustomFieldProto(obj).performSets({
                 type: "text"
             });
-        });
+        };
 
-        var numberProtos = self.db().findByType("CustomPropertyNumberProto").map(function(obj) {
+        var createNumberProto = function(obj) {
             return createBasicCustomFieldProto(obj).performSets({
                 type: "number",
                 precision: obj.precision
             });
-        });
+        };
 
-        var enumProtos = self.db().findByType("CustomPropertyEnumProto").map(function(obj) {
+        var createEnumProto = function(obj) {
             var options = self.db().findOrderedChildrenByType("custom_field_enum_option", obj.__object_id, "CustomPropertyEnumOption").map(function(option) {
                 return {
                     sourceId: option.__object_id,
@@ -213,9 +230,18 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                 type: "enum",
                 options: options
             });
-        });
+        };
 
-        return textProtos.concat(numberProtos, enumProtos);
+        if (obj.__type === "CustomPropertyTextProto") {
+            return createTextProto(obj);
+        } else  if (obj.__type === "CustomPropertyNumberProto") {
+            return createNumberProto(obj);
+        } else if (obj.__type === "CustomPropertyEnumProto") {
+            return createEnumProto(obj);
+        } else {
+            // If we don't understand the type of the proto return null
+            return null;
+        }
     },
 
     projects: function() {
@@ -239,8 +265,10 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                 var isBoard = columnsBySourceProjectId[obj.__object_id] !== undefined;
 
                 var customFieldSettings = self.db().findOrderedChildrenByType("custom_field_project_settings", obj.__object_id, "CustomPropertyProjectSetting").map(function(projectSetting) {
+                    var customFieldProtoDbObject = self.db().findById(projectSetting.proto);
+                    var customFieldProtoImportObject = customFieldProtoDbObject ? self._createCustomFieldProto(customFieldProtoDbObject) : null;
                     return {
-                        sourceCustomFieldProtoId: projectSetting.proto,
+                        sourceCustomFieldProto: customFieldProtoImportObject,
                         isImportant: projectSetting.is_important,
                         sourceId: projectSetting.__object_id
                     };

--- a/lib/asana_export_importer/AsanaApiExt.js
+++ b/lib/asana_export_importer/AsanaApiExt.js
@@ -8,10 +8,6 @@ aei.asana.resources.Projects.prototype.addFollowers = function(projectId, data) 
     return this.dispatcher.post('/projects/' + projectId + '/addFollowers', data);
 };
 
-aei.asana.resources.Projects.prototype.addCustomFieldSetting = function(projectId, data) {
-    return this.dispatcher.post('/projects/' + projectId + '/addCustomFieldSetting', data);
-};
-
 aei.asana.resources.Tasks.prototype.findByWorkspace = function(workspaceId, params) {
     return this.dispatcher.get('/workspaces/' + workspaceId + '/tasks', params);
 };

--- a/lib/asana_export_importer/Importer.js
+++ b/lib/asana_export_importer/Importer.js
@@ -13,7 +13,7 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
 
     _runImport: function() {
         this._importTeams();
-        this._importCustomFieldProtos();
+        this._importPublishedCustomFieldProtos();
         this._importProjects();
         this._addCustomFieldSettingsToProjects();
         this._importColumns();
@@ -48,7 +48,7 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
         }, "importing teams");
     },
 
-    _importCustomFieldProtos: function() {
+    _importPublishedCustomFieldProtos: function() {
         this._forEachOfType("customFieldProto", function(customFieldProto) {
             if (customFieldProto.isPublishedToDomain() !== false) {
                 customFieldProto.setWorkspaceId(this.organizationId());

--- a/lib/asana_export_importer/models/CustomFieldProto.js
+++ b/lib/asana_export_importer/models/CustomFieldProto.js
@@ -23,6 +23,7 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
     creationSource: null,
     isPublishedToDomain: null
 }).setSlots({
+
     _createResource: function(resourceData) {
         var self = this;
 
@@ -62,6 +63,17 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
             response = aei.Future.withPromise(this._resource().create(amendedResourceData)).wait();
         }
 
+        self.storeAdditionalIdsCreated(response);
+
+        return response;
+    },
+
+    /**
+     * Save ids for any additional objects that were created while creating the
+     * custom property proto. For example, save custom property enum option ids.
+     */
+    storeAdditionalIdsCreated(customFieldFromResponse) {
+        var self = this;
         if (self.type() === "enum") {
             // Enum options are created during the creation of the enum proto.
             // However, we need their IDs, to reference them in values later.
@@ -73,13 +85,19 @@ var CustomFieldProto = module.exports = aei.ImportObject.extend().performSets({
                 // returned by the cache, it doesn't contain the option IDs, but
                 // the previous run will have already put them in the map.
                 if (self.app().sourceToAsanaMap().at(exportOption.sourceId) === null) {
-                    var apiOption = response.enum_options[i];
+                    var apiOption = customFieldFromResponse.enum_options[i];
                     self.app().sourceToAsanaMap().atPut(exportOption.sourceId, apiOption.id);
                 }
             });
         }
+    },
 
-        return response;
+    /**
+     * Expose resource data publically so that we can also
+     * use it to create custom properties via the project.addCustomFieldSetting endpoint
+     */
+    creationData: function() {
+        return this._resourceData();
     },
 
     _resourceData: function() {

--- a/lib/asana_export_importer/models/Project.js
+++ b/lib/asana_export_importer/models/Project.js
@@ -38,15 +38,35 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
         var sourceToAsanaMap = self.app().sourceToAsanaMap();
 
         self.customFieldSettings().forEach(function(customFieldSetting) {
-            var customFieldProtoAsanaId = sourceToAsanaMap.at(customFieldSetting.sourceCustomFieldProtoId);
-
-            // Skip if the proto wasn't imported, because we assume it was trashed in the export
-            if (customFieldProtoAsanaId !== null) {
-                aei.Future.withPromise(self._resource().addCustomFieldSetting(self.asanaId(), {
-                    custom_field: customFieldProtoAsanaId,
+            var sourceCustomField = customFieldSetting.sourceCustomFieldProto;
+            if (sourceCustomField && sourceCustomField.isPublishedToDomain() === false) {
+                // If the field is local we must create a new field and store its information here
+                sourceCustomField.setWorkspaceId(self.workspaceId());
+                var response = aei.Future.withPromise(self._resource().addCustomFieldSetting(self.asanaId(), {
+                    custom_field: sourceCustomField.creationData(),
                     is_important: customFieldSetting.isImportant,
                     _sourceId: customFieldSetting.sourceId
                 })).wait();
+                // node-asana does not currently support getting extra fields back from post
+                // requests so we need to make a get request to learn what enum options were created.
+                var custom_field_response = aei.Future.withPromise(
+                    self.app().apiClient().customFields.findById(response.custom_field.id)
+                ).wait();
+
+                self.app().sourceToAsanaMap().atPut(sourceCustomField.sourceId(), response.custom_field.id);
+                sourceCustomField.storeAdditionalIdsCreated(custom_field_response);
+            } else if (sourceCustomField) {
+                // If the field is global we simply attach the existing field to this project
+                var customFieldProtoAsanaId = sourceToAsanaMap.at(sourceCustomField.sourceId());
+
+                // Skip if the proto wasn't imported, because we assume it was trashed in the export
+                if (customFieldProtoAsanaId !== null) {
+                    aei.Future.withPromise(self._resource().addCustomFieldSetting(self.asanaId(), {
+                        custom_field: customFieldProtoAsanaId,
+                        is_important: customFieldSetting.isImportant,
+                        _sourceId: customFieldSetting.sourceId
+                    })).wait();
+                }
             }
         });
     },


### PR DESCRIPTION
Custom fields that are not published to the domain can only be created through the project.addCustomFieldSetting endpoint.
Therefore, we must create these custom fields during the addCustomFieldSettings portion of the domain importer rather than during the importCustomFields portion.

To allow us to have access to custom field information during the addCustomFieldSettings portion of the import, project's customFieldSettings array has been updated to include CustomFieldProto objects instead of just including the ids.