### PR TITLE
Change how isBoard is calculated from project layout

### DIFF
--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -246,7 +246,6 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
 
     projects: function() {
         var self = this;
-        var columnsBySourceProjectId = this.columnsBySourceProjectId();
         return this.db().findByType("ItemList").map(function(obj){
             if (obj.is_project && !obj.assignee) {
                 var sourceMemberIds = self.db().findByType("ProjectMembership").filterProperty("project", obj.__object_id).map(function(pm){
@@ -262,20 +261,18 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     return sourceMemberIds.contains(uid);
                 }).emptiesRemoved();
 
-                var isBoard = columnsBySourceProjectId[obj.__object_id] !== undefined;
-
-                // This does not work yet, but will work when API introduce a default_view field
-                // FIXME # https://app.asana.com/0/750765658990796/1124894725392293
                 // Default view is obtained from project.default_view_json.view_mode
                 // If view_mode == "list" then default view is "list"
                 // If view_mode == "board" then default view is "board
-                // If view_mode == "timeline", "calendar" or anything else, check if project has columns
-                // Currently we can only set layout to be List or Board
-                var defaultView = "list";
+                // If view_mode == "timeline", "calendar" or missing, default to list view, because the
+                // API can't control the other views, and a missing view_mode implies list view.
+                var isBoard = false;
                 if (obj.hasOwnProperty("default_view_json")) {
                     const project_default_view = JSON.parse(obj.default_view_json);
                     if (project_default_view.hasOwnProperty("view_mode")) {
-                        defaultView = project_default_view["view_mode"];
+                        if (project_default_view["view_mode"] === "board") {
+                            isBoard = true;
+                        }
                     }
                 }
 
@@ -302,7 +299,6 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     sourceMemberIds: sourceMemberIds,
                     sourceFollowerIds: sourceFollowerIds,
                     customFieldSettings: customFieldSettings,
-                    defaultView: defaultView,
                 });
             }
         }).filter(function(project) { return project && project.sourceTeamId(); });

--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -262,8 +262,17 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     return sourceMemberIds.contains(uid);
                 }).emptiesRemoved();
 
-                const project_layout = obj.layout;
-                var isBoard = project_layout === "board";
+                // Default view is by default list-view, but is "view_mode" is "board" in project.default_view_json
+                // then we switch to list view.
+                // Currently we can only set layout to be List or Board and
+                // we cannot set default view as Timeline/Calendar on the API through pot.layout yet
+                var isBoard = false;
+                if (obj.hasOwnProperty("default_view_json")) {
+                    const project_default_view = JSON.parse(obj.default_view_json);
+                    if (project_default_view.hasOwnProperty("view_mode")) {
+                        isBoard = (project_default_view["view_mode"] === "board");
+                    }
+                }
 
                 var customFieldSettings = self.db().findOrderedChildrenByType("custom_field_project_settings", obj.__object_id, "CustomPropertyProjectSetting").map(function(projectSetting) {
                     var customFieldProtoDbObject = self.db().findById(projectSetting.proto);

--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -262,15 +262,20 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     return sourceMemberIds.contains(uid);
                 }).emptiesRemoved();
 
-                // Default view is by default list-view, but is "view_mode" is "board" in project.default_view_json
-                // then we switch to list view.
-                // Currently we can only set layout to be List or Board and
-                // we cannot set default view as Timeline/Calendar on the API through pot.layout yet
-                var isBoard = false;
+                var isBoard = columnsBySourceProjectId[obj.__object_id] !== undefined;
+
+                // This does not work yet, but will work when API introduce a default_view field
+                // FIXME # https://app.asana.com/0/750765658990796/1124894725392293
+                // Default view is obtained from project.default_view_json.view_mode
+                // If view_mode == "list" then default view is "list"
+                // If view_mode == "board" then default view is "board
+                // If view_mode == "timeline", "calendar" or anything else, check if project has columns
+                // Currently we can only set layout to be List or Board
+                var defaultView = "list";
                 if (obj.hasOwnProperty("default_view_json")) {
                     const project_default_view = JSON.parse(obj.default_view_json);
                     if (project_default_view.hasOwnProperty("view_mode")) {
-                        isBoard = (project_default_view["view_mode"] === "board");
+                        defaultView = project_default_view["view_mode"];
                     }
                 }
 
@@ -296,7 +301,8 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     sourceItemIds: obj.items,
                     sourceMemberIds: sourceMemberIds,
                     sourceFollowerIds: sourceFollowerIds,
-                    customFieldSettings: customFieldSettings
+                    customFieldSettings: customFieldSettings,
+                    defaultView: defaultView,
                 });
             }
         }).filter(function(project) { return project && project.sourceTeamId(); });

--- a/lib/asana_export/AsanaExport.js
+++ b/lib/asana_export/AsanaExport.js
@@ -262,7 +262,8 @@ var AsanaExport = module.exports = ae.aei.Export.extend().newSlots({
                     return sourceMemberIds.contains(uid);
                 }).emptiesRemoved();
 
-                var isBoard = columnsBySourceProjectId[obj.__object_id] !== undefined;
+                const project_layout = obj.layout;
+                var isBoard = project_layout === "board";
 
                 var customFieldSettings = self.db().findOrderedChildrenByType("custom_field_project_settings", obj.__object_id, "CustomPropertyProjectSetting").map(function(projectSetting) {
                     var customFieldProtoDbObject = self.db().findById(projectSetting.proto);

--- a/lib/asana_export_importer/models/Project.js
+++ b/lib/asana_export_importer/models/Project.js
@@ -11,6 +11,7 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
     public: false,
     color: null,
     isBoard: false,
+    defaultView: "list",
     sourceTeamId: null,
     sourceItemIds: null,
     sourceMemberIds: null,
@@ -90,6 +91,7 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
             public: this.public(),
             color: this.color(),
             team: this.asanaTeamId(),
+            default_view: this.defaultView(),
             layout: this.isBoard() ? "BOARD" : "LIST"
         };
     },

--- a/lib/asana_export_importer/models/Project.js
+++ b/lib/asana_export_importer/models/Project.js
@@ -11,7 +11,6 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
     public: false,
     color: null,
     isBoard: false,
-    defaultView: "list",
     sourceTeamId: null,
     sourceItemIds: null,
     sourceMemberIds: null,
@@ -91,7 +90,6 @@ var Project = module.exports = aei.ImportObject.extend().performSets({
             public: this.public(),
             color: this.color(),
             team: this.asanaTeamId(),
-            default_view: this.defaultView(),
             layout: this.isBoard() ? "BOARD" : "LIST"
         };
     },

--- a/test/asana_export/AsanaExport.js
+++ b/test/asana_export/AsanaExport.js
@@ -112,7 +112,7 @@ describe("AsanaExport", function() {
         });
 
         it("should return a list project if there are no columns and layout is list", function() {
-            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, layout: "list" });
+            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, default_view_json: "{'view_mode': 'list'}" });
             exp.prepareForImport();
 
             exp.projects().mapPerform("performGets", ["isBoard"]).should.deep.equal([
@@ -121,7 +121,7 @@ describe("AsanaExport", function() {
         });
 
         it("should return a list project if there are columns but layout is list", function() {
-            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, layout: "list" });
+            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, default_view_json: "{'view_mode': 'list'}" });
             exp.addObject(2, "Column", { name: "First column", pot: 1, rank: "V" });
             exp.prepareForImport();
 
@@ -131,7 +131,7 @@ describe("AsanaExport", function() {
         });
 
         it("should return a board project if there are columns and layout is column", function() {
-            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, layout: "board"});
+            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, default_view_json: "{'view_mode': 'board'}"});
             exp.addObject(2, "Column", { name: "First column", pot: 1, rank: "V" });
             exp.prepareForImport();
 

--- a/test/asana_export/AsanaExport.js
+++ b/test/asana_export/AsanaExport.js
@@ -112,7 +112,7 @@ describe("AsanaExport", function() {
         });
 
         it("should return a list project if there are no columns and layout is list", function() {
-            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, default_view_json: "{'view_mode': 'list'}" });
+            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, default_view_json: "{\"view_mode\": \"list\"}" });
             exp.prepareForImport();
 
             exp.projects().mapPerform("performGets", ["isBoard"]).should.deep.equal([
@@ -121,7 +121,7 @@ describe("AsanaExport", function() {
         });
 
         it("should return a list project if there are columns but layout is list", function() {
-            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, default_view_json: "{'view_mode': 'list'}" });
+            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, default_view_json: "{\"view_mode\": \"list\"}" });
             exp.addObject(2, "Column", { name: "First column", pot: 1, rank: "V" });
             exp.prepareForImport();
 
@@ -131,7 +131,7 @@ describe("AsanaExport", function() {
         });
 
         it("should return a board project if there are columns and layout is column", function() {
-            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, default_view_json: "{'view_mode': 'board'}"});
+            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, default_view_json: "{\"view_mode\": \"board\"}"});
             exp.addObject(2, "Column", { name: "First column", pot: 1, rank: "V" });
             exp.prepareForImport();
 

--- a/test/asana_export/AsanaExport.js
+++ b/test/asana_export/AsanaExport.js
@@ -111,8 +111,8 @@ describe("AsanaExport", function() {
             ]);
         });
 
-        it("should return a list project if there are no columns", function() {
-            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4 });
+        it("should return a list project if there are no columns and layout is list", function() {
+            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, layout: "list" });
             exp.prepareForImport();
 
             exp.projects().mapPerform("performGets", ["isBoard"]).should.deep.equal([
@@ -120,8 +120,18 @@ describe("AsanaExport", function() {
             ]);
         });
 
-        it("should return a board project if there are columns", function() {
-            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4 });
+        it("should return a list project if there are columns but layout is list", function() {
+            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, layout: "list" });
+            exp.addObject(2, "Column", { name: "First column", pot: 1, rank: "V" });
+            exp.prepareForImport();
+
+            exp.projects().mapPerform("performGets", ["isBoard"]).should.deep.equal([
+                { isBoard: false }
+            ]);
+        });
+
+        it("should return a board project if there are columns and layout is column", function() {
+            exp.addObject(1, "ItemList", { followers_du: [], is_project: true, team: 4, layout: "board"});
             exp.addObject(2, "Column", { name: "First column", pot: 1, rank: "V" });
             exp.prepareForImport();
 


### PR DESCRIPTION
* We used to calculate isBoard using whether project has a column or not
* Now we use layout from the API instead https://asana.com/developers/api-reference/projects

See this for more context https://app.asana.com/0/750765658990796/1124903893141480

Testing plan: 
1) creating my test data on sand with:
- old list project
- new column-back project with default_view = list
- new column-back project with default_view = board
-  new column-back project with default_view = calendar.

2) Then I ran export_domain.rb to obtain the test_export.json file. 
3) I use that test_export.json file and import in our import test domain.