### PR TITLE
Don't try to reuse existing tags with the same name

### DIFF
--- a/lib/asana_export_importer/AsanaClientWrapper.js
+++ b/lib/asana_export_importer/AsanaClientWrapper.js
@@ -20,8 +20,8 @@ var AsanaClientWrapper = module.exports = aei.ideal.Proto.extend().setType("Asan
         return this.client().dispatcher.dispatch(params).then(function(result) {
             if (result === undefined || result.data === undefined) {
                 // We expect all requests to return a result. Fail fast if they don't, so we get retry behavior
-                console.log("Failed request params: " + params);
-                console.log("Failed request result: " + result);
+                console.log("Failed request params", params);
+                console.log("Failed request result", result);
                 throw new Error("Request against the Asana API did not return a result", params);
             }
             return result;

--- a/lib/asana_export_importer/AsanaClientWrapper.js
+++ b/lib/asana_export_importer/AsanaClientWrapper.js
@@ -20,6 +20,8 @@ var AsanaClientWrapper = module.exports = aei.ideal.Proto.extend().setType("Asan
         return this.client().dispatcher.dispatch(params).then(function(result) {
             if (result === undefined || result.data === undefined) {
                 // We expect all requests to return a result. Fail fast if they don't, so we get retry behavior
+                console.log("Failed request params: " + params);
+                console.log("Failed request result: " + result);
                 throw new Error("Request against the Asana API did not return a result", params);
             }
             return result;

--- a/lib/asana_export_importer/Importer.js
+++ b/lib/asana_export_importer/Importer.js
@@ -98,7 +98,7 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
         // Collections contain the first page of results, but represent all the results, and have a neat "fetch"
         // ability to load all the results gradually.
         // var existingTags = aei.Future.withPromise(firstPageCollection.fetch()).wait();
-        var existingTags = aei.Future.withPromise(this.app().apiClient().tags.findByWorkspace(this.organizationId())).wait().data;
+        var existingTags = aei.Future.withPromise(this.app().apiClient().tags.findAll({ workspace: this.organizationId() })).wait().data;
         this._forEachOfType("tag", function(tag) {
             tag.setWorkspaceId(this.organizationId());
 

--- a/lib/asana_export_importer/Importer.js
+++ b/lib/asana_export_importer/Importer.js
@@ -94,11 +94,10 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
     },
 
     _importTags: function() {
-        // var firstPageCollection = aei.Future.withPromise(this.app().apiClient().tags.findByWorkspace(this.organizationId(), {limit: 20})).wait();
+        var firstPageCollection = aei.Future.withPromise(this.app().apiClient().tags.findByWorkspace(this.organizationId(), {limit: 20})).wait();
         // Collections contain the first page of results, but represent all the results, and have a neat "fetch"
         // ability to load all the results gradually.
-        // var existingTags = aei.Future.withPromise(firstPageCollection.fetch()).wait();
-        var existingTags = aei.Future.withPromise(this.app().apiClient().tags.findAll({ workspace: this.organizationId() })).wait().data;
+        var existingTags = aei.Future.withPromise(firstPageCollection.fetch()).wait();
         this._forEachOfType("tag", function(tag) {
             tag.setWorkspaceId(this.organizationId());
 

--- a/lib/asana_export_importer/Importer.js
+++ b/lib/asana_export_importer/Importer.js
@@ -94,7 +94,7 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
     },
 
     _importTags: function() {
-        var firstPageCollection = aei.Future.withPromise(this.app().apiClient().tags.findByWorkspace(this.organizationId(), {limit: 100})).wait();
+        var firstPageCollection = aei.Future.withPromise(this.app().apiClient().tags.findByWorkspace(this.organizationId(), {limit: 20})).wait();
         // Collections contain the first page of results, but represent all the results, and have a neat "fetch"
         // ability to load all the results gradually.
         var existingTags = aei.Future.withPromise(firstPageCollection.fetch()).wait();

--- a/lib/asana_export_importer/Importer.js
+++ b/lib/asana_export_importer/Importer.js
@@ -94,20 +94,11 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
     },
 
     _importTags: function() {
-        var firstPageCollection = aei.Future.withPromise(this.app().apiClient().tags.findByWorkspace(this.organizationId(), {limit: 20})).wait();
-        // Collections contain the first page of results, but represent all the results, and have a neat "fetch"
-        // ability to load all the results gradually.
-        var existingTags = aei.Future.withPromise(firstPageCollection.fetch()).wait();
         this._forEachOfType("tag", function(tag) {
             tag.setWorkspaceId(this.organizationId());
 
-            var existingTag = existingTags.detectProperty("name", tag.name());
-            if (existingTag) {
-                tag.setAsanaId(existingTag.id);
-            } else {
-                tag.setAsanaTeamId(this.app().sourceToAsanaMap().at(tag.sourceTeamId()));
-                tag.create();
-            }
+            tag.setAsanaTeamId(this.app().sourceToAsanaMap().at(tag.sourceTeamId()));
+            tag.create();
         }, "importing tags");
     },
 

--- a/lib/asana_export_importer/Importer.js
+++ b/lib/asana_export_importer/Importer.js
@@ -94,10 +94,11 @@ var Importer = module.exports = aei.ideal.Proto.extend().setType("Importer").new
     },
 
     _importTags: function() {
-        var firstPageCollection = aei.Future.withPromise(this.app().apiClient().tags.findByWorkspace(this.organizationId(), {limit: 20})).wait();
+        // var firstPageCollection = aei.Future.withPromise(this.app().apiClient().tags.findByWorkspace(this.organizationId(), {limit: 20})).wait();
         // Collections contain the first page of results, but represent all the results, and have a neat "fetch"
         // ability to load all the results gradually.
-        var existingTags = aei.Future.withPromise(firstPageCollection.fetch()).wait();
+        // var existingTags = aei.Future.withPromise(firstPageCollection.fetch()).wait();
+        var existingTags = aei.Future.withPromise(this.app().apiClient().tags.findByWorkspace(this.organizationId())).wait().data;
         this._forEachOfType("tag", function(tag) {
             tag.setWorkspaceId(this.organizationId());
 


### PR DESCRIPTION
A user can only see tags that contain at least one task that they can see. That has 2 effects that are relevant here:

1. It takes forever to load tags in some domains, and times out https://app.asana.com/0/2002711484875/1139102097462521
2. The bot user mostly can't see the relevant tags anyway, and we've been fine importing potentially-duplicate tags for years

So now we'll just import tags regardless of name clashes. It works.